### PR TITLE
Make oppskrift grid config use its own horizontalBase

### DIFF
--- a/src/themes/oppskrift/index.js
+++ b/src/themes/oppskrift/index.js
@@ -1,4 +1,5 @@
 import { css } from 'styled-components';
+import { stripUnit } from 'polished';
 import colors from './colors';
 import variables from './variables';
 
@@ -29,6 +30,10 @@ const theme = {
 	global,
 	colors,
 	variables,
+
+	flexboxgrid: {
+		gutterWidth: stripUnit(variables.horizontalBase), // rem
+	},
 };
 
 export default theme;


### PR DESCRIPTION
I just realized that if you don't override the grid, it will use the horizontalBase from the default theme. Here's a quick fix for the 'oppskrift' theme.