### PR TITLE
Iterate on recipe header

### DIFF
--- a/src/atoms/HorizontalFlexingList.js
+++ b/src/atoms/HorizontalFlexingList.js
@@ -7,6 +7,7 @@ const HorizontalFlexingList = styled.ul`
 		? `
 			display: flex;
 			align-items: center;
+			justify-content: ${props.justifyContent};
 		` : `
 			display: block;
 		`
@@ -34,5 +35,9 @@ const HorizontalFlexingList = styled.ul`
 		display: none;
 	}
 `;
+HorizontalFlexingList.defaultProps = {
+	shouldFlexChildren: false,
+	justifyContent: 'initial',
+};
 
 export { HorizontalFlexingList };

--- a/src/atoms/LinkBarItem.js
+++ b/src/atoms/LinkBarItem.js
@@ -1,44 +1,18 @@
 import styled from 'styled-components';
 import propTypes from 'prop-types';
-
-const display = 'inline-block';
+import { hideWithFlexboxgridSyntax } from '../utils/hide-with-flexboxgrid-syntax';
 
 const LinkBarItem = styled.li`
 	position: relative;
-	display: ${display};
 	vertical-align: middle;
 	line-height: 0;
 	margin: 0;
 	flex: ${props => (props.flex)};
 	z-index: 8;
 
-	&:last-child {
-		margin-right: calc(2 * ${props => props.theme.variables.horizontalBase});
-	}
-
 	/* This whole block deals with hiding the LinkBarItem */
 	/* with syntax from react-styled-flexboxgrid */
-	${(props) => {
-		const {
-			xs, sm, md, lg,
-			theme: {
-				flexboxgrid: {
-					breakpoints: {
-						xs: xsBreak, sm: smBreak, md: mdBreak, lg: lgBreak,
-					},
-				},
-			},
-		} = props;
-
-		const acc = [];
-
-		xs !== null && acc.push(`@media only screen and (min-width: ${xsBreak}em) { display: ${xs ? display : 'none'}}`);
-		sm !== null && acc.push(`@media only screen and (min-width: ${smBreak}em) { display: ${sm ? display : 'none'}}`);
-		md !== null && acc.push(`@media only screen and (min-width: ${mdBreak}em) { display: ${md ? display : 'none'}}`);
-		lg !== null && acc.push(`@media only screen and (min-width: ${lgBreak}em) { display: ${lg ? display : 'none'}}`);
-
-		return acc.join('\n');
-	}}
+	${hideWithFlexboxgridSyntax('inline-block')}
 	`;
 
 LinkBarItem.propTypes = {
@@ -54,7 +28,7 @@ LinkBarItem.defaultProps = {
 	sm: null,
 	md: null,
 	lg: null,
-	flex: '1 0 auto',
+	flex: '0 0 auto',
 };
 
 export { LinkBarItem };

--- a/src/atoms/MatHeader/TopBarSearchField.js
+++ b/src/atoms/MatHeader/TopBarSearchField.js
@@ -1,4 +1,5 @@
 import Styled from 'styled-components';
+import { hideWithFlexboxgridSyntax } from '../../utils/hide-with-flexboxgrid-syntax';
 
 const TopBarSearchField = Styled.input`
 	height: 38px;
@@ -6,10 +7,18 @@ const TopBarSearchField = Styled.input`
 	float: right;
 	padding: 11px 15px 9px;
 	font-size: 15px;
-	
+
 	&::placeholder {
 		color: gray;
 	}
+
+	${hideWithFlexboxgridSyntax('block')}
 `;
+TopBarSearchField.defaultProps = {
+	xs: null,
+	sm: null,
+	md: null,
+	lg: null,
+};
 
 export { TopBarSearchField };

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ export { LeetTextarea            } from './atoms/LeetTextarea';
 export { Link                    } from './atoms/Link';
 export { ListItem                } from './atoms/ListItem';
 export { LunchKicker             } from './atoms/LunchKicker';
+export { MatLogo                 } from './atoms/MatLogo';
 export { NativeAdKicker          } from './atoms/NativeAdKicker';
 export { Pips                    } from './atoms/Pips';
 export { PublishedDate           } from './atoms/PublishedDate';

--- a/src/molecules/HorizontalLinkBar.js
+++ b/src/molecules/HorizontalLinkBar.js
@@ -27,6 +27,9 @@ const LinkBar = ({
 		>
 			<Bar background={background} {...rest}>
 				{children && children.map((child, i) => {
+					if (child.props && child.props.isListItem) {
+						return child;
+					}
 					return (
 						<LinkBarItem key={i} {...child.props}>
 							{child}
@@ -34,9 +37,7 @@ const LinkBar = ({
 					);
 				})}
 			</Bar>
-			{shouldFadeOut &&
-			<HorizontalOverflowGradient />
-			}
+			{shouldFadeOut && <HorizontalOverflowGradient />}
 		</NavWithOptionalConstrainer>
 	);
 };

--- a/src/utils/hide-with-flexboxgrid-syntax.js
+++ b/src/utils/hide-with-flexboxgrid-syntax.js
@@ -1,0 +1,40 @@
+/**
+ * Hide a styled-component with syntax familiar to users of react-styled-flexboxgrid.
+ *
+ * Example usage:
+ * const Foo = styled.div`
+ *   ${hideWithFlexboxgridSyntax('inline-block')}
+ * `
+ * Foo.defaultProps = {
+ *   xs: null,
+ *   sm: null,
+ *   md: null,
+ *   lg: null,
+ * }
+ */
+const hideWithFlexboxgridSyntax = (display) => {
+	return (props) => {
+		const {
+			xs, sm, md, lg,
+			theme: {
+				flexboxgrid: {
+					breakpoints: {
+						xs: xsBreak, sm: smBreak, md: mdBreak, lg: lgBreak,
+					},
+				},
+			},
+		} = props;
+
+		const acc = [];
+
+		acc.push(`display: ${display};`);
+		xs !== null && acc.push(`@media only screen and (min-width: ${xsBreak}em) { display: ${xs ? display : 'none'}}`);
+		sm !== null && acc.push(`@media only screen and (min-width: ${smBreak}em) { display: ${sm ? display : 'none'}}`);
+		md !== null && acc.push(`@media only screen and (min-width: ${mdBreak}em) { display: ${md ? display : 'none'}}`);
+		lg !== null && acc.push(`@media only screen and (min-width: ${lgBreak}em) { display: ${lg ? display : 'none'}}`);
+
+		return acc.join('\n');
+	};
+};
+
+export { hideWithFlexboxgridSyntax };

--- a/stories/link-bars/MatStory.js
+++ b/stories/link-bars/MatStory.js
@@ -31,6 +31,13 @@ const LinkBarBleedingLogo = LinkBarItem.extend`
 	z-index: 9;
 `;
 
+const linkProps = {
+	useUnderline: false,
+	activeBackground: 'transparent',
+	activeTextColor: 'primary',
+	textColor: 'type',
+};
+
 const MatStory = () => (
 	<section>
 		<HugeHeading>Mat-like header</HugeHeading>
@@ -57,9 +64,9 @@ const MatStory = () => (
 				textColor="white"
 			>
 				<VerticalLinkBar background="white">
-					<LinkBarLink linkText="Test" url="#" />
-					<LinkBarLink linkText="Test" url="#" />
-					<LinkBarLink linkText="Test" url="#" />
+					<LinkBarLink linkText="Test" url="#" {...linkProps} />
+					<LinkBarLink linkText="Test" url="#" {...linkProps} />
+					<LinkBarLink linkText="Test" url="#" {...linkProps} />
 				</VerticalLinkBar>
 			</LinkBarDropdown>
 		</HorizontalLinkBar>
@@ -70,43 +77,31 @@ const MatStory = () => (
 			justifyContent="center"
 		>
 			<LinkBarLink
-				useUnderline={false}
-				activeBackground="white"
 				linkText="Oppskrifter"
-				activeTextColor="primary"
 				url="#"
-				textColor="type"
+				{...linkProps}
 				isActive
 				xs={false}
 				md
 			/>
 			<LinkBarLink
-				useUnderline={false}
-				activeBackground="white"
-				linkText="Train-For-Trinn-Video"
+				linkText="Trinn-for-trinn-video"
 				url="#"
-				textColor="type"
-				activeTextColor="primary"
+				{...linkProps}
 				xs={false}
 				md
 			/>
 			<LinkBarLink
-				useUnderline={false}
-				activeBackground="white"
-				linkText="Bli Inspirert"
+				linkText="Bli inspirert"
 				url="https://example.com"
-				textColor="type"
-				activeTextColor="primary"
+				{...linkProps}
 				xs={false}
-				lg
+				md
 			/>
 			<LinkBarLink
-				useUnderline={false}
-				activeBackground="white"
-				linkText="Populært Nå"
+				linkText="Populært nå"
 				url="https://example.com"
-				textColor="type"
-				activeTextColor="primary"
+				{...linkProps}
 				xs={false}
 				lg
 			/>

--- a/stories/link-bars/MatStory.js
+++ b/stories/link-bars/MatStory.js
@@ -10,7 +10,6 @@ import {
 	LinkBarItem,
 	LinkBarDropdown,
 	VerticalLinkBar,
-	FontIcon,
 } from '../../src/';
 
 import { TopBarSearchField } from '../../src/atoms/MatHeader/TopBarSearchField';

--- a/stories/link-bars/MatStory.js
+++ b/stories/link-bars/MatStory.js
@@ -1,43 +1,115 @@
 import React from 'react';
+import styled from 'styled-components';
 
-import { LinkBarLink       } from '../../src/atoms/LinkBarLink';
-import { HorizontalLinkBar } from '../../src/molecules/HorizontalLinkBar';
+import {
+	LinkBarLink,
+	XSmallLinkBarLink,
+	HorizontalLinkBar,
+	MatLogo,
+	HugeHeading,
+	LinkBarItem,
+	LinkBarDropdown,
+	VerticalLinkBar,
+	FontIcon,
+} from '../../src/';
+
+import { TopBarSearchField } from '../../src/atoms/MatHeader/TopBarSearchField';
+
+const LogoLink = styled(XSmallLinkBarLink)`
+	position: absolute;
+	top:0;
+	width: 14.6rem;
+`;
+
+const SearchField = TopBarSearchField.extend`
+	box-sizing: border-box;
+	margin: .8rem 0;
+	max-width: calc(100% - 21rem);
+`;
+
+const LinkBarBleedingLogo = LinkBarItem.extend`
+	align-self: flex-start;
+	z-index: 9;
+`;
 
 const MatStory = () => (
 	<section>
-		<HorizontalLinkBar background={'white'}>
+		<HugeHeading>Mat-like header</HugeHeading>
+		<HorizontalLinkBar
+			isTopLevelComponent={false} // Use the full width
+			background="#4a4a4a" // A refactor to bacground='splashBackground' is on the books
+			shouldFlexChildren
+			justifyContent="space-between"
+			overflow="visible"
+		>
+			<LinkBarBleedingLogo isListItem>
+				<LogoLink useUnderline={false}>
+					<MatLogo />
+				</LogoLink>
+			</LinkBarBleedingLogo>
+			<SearchField
+				placeholder="Søk i oppskrifter..."
+				xs={false}
+				md
+			/>
+			<LinkBarDropdown
+				md={false}
+				linkText="☰"
+				textColor="white"
+			>
+				<VerticalLinkBar background="white">
+					<LinkBarLink linkText="Test" url="#" />
+					<LinkBarLink linkText="Test" url="#" />
+					<LinkBarLink linkText="Test" url="#" />
+				</VerticalLinkBar>
+			</LinkBarDropdown>
+		</HorizontalLinkBar>
+		<HorizontalLinkBar
+			background="white"
+			isTopLevelComponent={false} // Use the full width
+			shouldFlexChildren
+			justifyContent="center"
+		>
 			<LinkBarLink
 				useUnderline={false}
-				activeBackground={'white'}
+				activeBackground="white"
 				linkText="Oppskrifter"
-				activeTextColor={'primary'}
+				activeTextColor="primary"
 				url="#"
-				textColor={'type'}
+				textColor="type"
 				isActive
+				xs={false}
+				md
 			/>
 			<LinkBarLink
 				useUnderline={false}
-				activeBackground={'white'}
+				activeBackground="white"
 				linkText="Train-For-Trinn-Video"
 				url="#"
-				textColor={'type'}
-				activeTextColor={'primary'}
+				textColor="type"
+				activeTextColor="primary"
+				xs={false}
+				md
 			/>
 			<LinkBarLink
 				useUnderline={false}
-				activeBackground={'white'}
+				activeBackground="white"
 				linkText="Bli Inspirert"
 				url="https://example.com"
-				textColor={'type'}
-				activeTextColor={'primary'}
+				textColor="type"
+				activeTextColor="primary"
+				xs={false}
+				lg
 			/>
 			<LinkBarLink
 				useUnderline={false}
-				activeBackground={'white'}
+				activeBackground="white"
 				linkText="Populært Nå"
 				url="https://example.com"
-				textColor={'type'}
-				activeTextColor={'primary'}
+				textColor="type"
+				activeTextColor="primary"
+				xs={false}
+				lg
 			/>
 		</HorizontalLinkBar>
 	</section>

--- a/stories/link-bars/index.js
+++ b/stories/link-bars/index.js
@@ -19,6 +19,7 @@ import { ButtonStory } from './ButtonStory';
 import { DropdownStory } from './DropdownStory';
 import { HideStory } from './HideStory';
 import { MatStory } from './MatStory';
+// import { SeHerStory } from './SeHerStory';
 
 import { DagbladetStory } from './DagbladetStory';
 
@@ -41,5 +42,6 @@ export default () => {
 		.add('LinkBarButton', ButtonStory)
 		.add('Hidden LinkBar elements', HideStory)
 		.add('Dagbladet-like bar', DagbladetStory)
+		// .add('SeHer-like bar', SeHerStory)
 		.add('MatStory link bar', MatStory);
 };


### PR DESCRIPTION
Extract a util from LinkBarLink to hide your styled-component depending on how wide your screen is.

In the Mat-like link bar story:
- Use the search input field from `atoms/MatHeader/TopBarSearchField`
- Otherwise use existing components: HorizontalLinkBar, LinkBarLink etc
- Demonstrate responsiveness in menu