### PR TITLE
simplified expression

### DIFF
--- a/src/atoms/LinkBarLink.js
+++ b/src/atoms/LinkBarLink.js
@@ -22,10 +22,7 @@ const LinkBarLink = ({
 LinkBarLink.propTypes = {
 	isActive: propTypes.bool,
 	linkText: propTypes.string,
-	children: propTypes.oneOf([
-		propTypes.node,
-		propTypes.arrayOf(propTypes.node),
-	]),
+	children: propTypes.node,
 	activeBackground: propTypes.string,
 	size: propTypes.oneOf(['xsmall', 'small', 'medium', 'large']),
 	url: propTypes.string,


### PR DESCRIPTION
Based on this: https://reactjs.org/docs/typechecking-with-proptypes.html
the correct way to say that it could be and element or and array of elements is to use node. 

No need to say that it could be and array of nodes, that is implicit when using node