### PR TITLE
Refactor StickyAd to use verticalBase

### DIFF
--- a/src/molecules/StickyAd.js
+++ b/src/molecules/StickyAd.js
@@ -14,7 +14,7 @@ const StyledAdWrapper = AdWrapper.extend`
 
 const StickyWrapper = styled.div`
 	position: absolute;
-	top: 0;
+	top: ${props => props.theme.variables.verticalBase};
 
 	@media screen and (min-width: ${props => props.theme.flexboxgrid.breakpoints.xs}em) {
 		${props => (


### PR DESCRIPTION
Currently the StickyAd has css `top: 0`. Changing this to use `props.theme.variables.verticalBase` instead so the StickyAds align with the rest of the content.