### PR TITLE
Fix missing itemtype and itemscope for WallpaperAd

### DIFF
--- a/src/molecules/WallpaperAd.js
+++ b/src/molecules/WallpaperAd.js
@@ -118,7 +118,9 @@ class WallpaperAd extends Component {
 	}
 
 	render() {
-		const { height, shouldHideAttribution } = this.props;
+		const {
+			height, shouldHideAttribution, itemType, itemScope,
+		} = this.props;
 
 		/* eslint-disable jsx-a11y/anchor-has-content */
 		const left = (
@@ -156,6 +158,8 @@ class WallpaperAd extends Component {
 					height={height}
 					width={this.state.isWallpaper ? '1010px' : '980px'}
 					shouldHideAttribution={shouldHideAttribution}
+					itemType={itemType}
+					itemScope={itemScope}
 				>
 					{React.cloneElement(this.props.children, {
 						onMediaQueryChange: this.onMediaQueryChange.bind(this),
@@ -171,6 +175,8 @@ WallpaperAd.propTypes = {
 	height: PropTypes.string,
 	children: PropTypes.node.isRequired,
 	shouldHideAttribution: PropTypes.bool.isRequired,
+	itemType: PropTypes.string.isRequired,
+	itemScope: PropTypes.bool.isRequired,
 };
 
 WallpaperAd.defaultProps = {


### PR DESCRIPTION
Setting these values will make ad blockers set display:none on the div, which will in turn remove large white boxes for people blocking ads.

#### Please tick a box ###
- [ ] **feature** _(A new feature_)
- [x] **fix** _(A bug fix_)
- [ ] **refactor** _(A code change that neither fixes a bug nor adds a feature_)
- [ ] **docs** _(Documentation only changes_)
- [ ] **performance** _(A code change that improves performance_)
- [ ] **style** _(Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)_)
- [ ] **build** _(Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)_)
- [ ] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)
- [ ] **test** _(Adding missing tests or correcting existing tests_)

#### If you're adding a feature, is it documented in a storybook story?
- [ ] Yes
- [ ] No

#### Are the components you're working on reusable between brands?
- [ ] Yes _(Using variables that are defined in the default theme)_
- [ ] No _(I hard coded some values)_

#### If you're creating markup, did you add proper semantics? 
- [ ] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [x] I added microdata from [Schema.org](http://schema.org/)
- [ ] Semantics are derived from HTML
- [ ] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
