### PR TITLE
Fix dropdown in header (temporary?)

### DIFF
--- a/src/atoms/VerticalFlexingList.js
+++ b/src/atoms/VerticalFlexingList.js
@@ -12,7 +12,7 @@ const VerticalFlexingList = styled.ul`
 	background: ${props => props.background};
 	position: relative;
 
-	${LinkBarDropdown} + * & {
+	${LinkBarDropdown} + div & {
 		display: ${props => (props.hide ? 'none' : 'flex')};
 		flex-direction: column;
 		position: absolute;


### PR DESCRIPTION
Issue with latest releases of styled-components. Styles with `${Ref} + * &` is not showing up. Swapped `*` with `div` to fix the issue for now so we don't end up being too far behind styled-components master. 

The problem does not seem to exist in SSR/next-less apps: https://codesandbox.io/s/32x1xq2woq

#### Please tick a box ###
- [ ] **feature** _(A new feature_)
- [ ] **fix** _(A bug fix_)
- [ ] **refactor** _(A code change that neither fixes a bug nor adds a feature_)
- [ ] **docs** _(Documentation only changes_)
- [ ] **performance** _(A code change that improves performance_)
- [ ] **style** _(Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)_)
- [ ] **build** _(Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)_)
- [ ] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)
- [ ] **test** _(Adding missing tests or correcting existing tests_)

#### If you're adding a feature, is it documented in a storybook story?
- [ ] Yes
- [ ] No

#### Are the components you're working on reusable between brands?
- [ ] Yes _(Using variables that are defined in the default theme)_
- [ ] No _(I hard coded some values)_

#### If you're creating markup, did you add proper semantics? 
- [ ] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [ ] I added microdata from [Schema.org](http://schema.org/)
- [ ] Semantics are derived from HTML
- [ ] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
