### PR TITLE
Inject classNames from component name

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
 	],
 	"plugins": [
 		"system-import-transformer",
-		"transform-object-assign"
+		"transform-object-assign",
+		["styled-components", { "ssr": true,	"displayName": true,  "preprocess": false }] 
     ]
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-cli": "6.26.0",
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
-		"styled-components": "^3.2.5"
+    "styled-components": "^3.2.5"
   },
   "dependencies": {
     "@aller/eslint-config-aller": "0.5.2",
@@ -27,6 +27,7 @@
     "@storybook/addon-links": "3.4.0",
     "@storybook/react": "3.4.0",
     "aurora-deep-slice-merge": "github:soldotno/aurora-deep-slice-merge",
+    "babel-plugin-styled-components": "1.5.1",
     "babel-plugin-system-import-transformer": "3.1.0",
     "babel-plugin-transform-object-assign": "6.22.0",
     "intersection-observer": "0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,12 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/helper-annotate-as-pure@^7.0.0-beta.37":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.44.tgz#8ecf33cc5235295afcc7f160a63cab17ce7776f4"
+  dependencies:
+    "@babel/types" "7.0.0-beta.44"
+
 "@babel/helper-function-name@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz#e18552aaae2231100a6e485e03854bc3532d44dd"
@@ -1040,6 +1046,14 @@ babel-plugin-react-docgen@^1.8.3:
     babel-types "^6.24.1"
     lodash "^4.17.0"
     react-docgen "^3.0.0-beta11"
+
+babel-plugin-styled-components@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.5.1.tgz#31dbeb696d1354d1585e60d66c7905f5e474afcd"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0-beta.37"
+    babel-types "^6.26.0"
+    stylis "^3.0.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -7191,7 +7205,7 @@ stylis-rule-sheet@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
 
-stylis@^3.5.0:
+stylis@^3.0.0, stylis@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
 


### PR DESCRIPTION
This feature adds readable classnames into the html and names styled components react components  better so that it's easier to understand what it is. Fixes #375 

#### What is this ###
- [ ] **feature** 

## Questions:
 Would this cause a performance regression ? should we only use it when `NODE_ENV` is not production or is it ok to on both? and If we should only have it in production, do we need to create 2 builds?
