### PR TITLE
ci(percy): Add more widths to Percy

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf storybook-static lib",
     "deploy": "./deploy.sh",
     "postinstall": "babel src/ -d lib/",
-    "snapshot": "build-storybook && percy-storybook --widths=320,1280 --debug",
+    "snapshot": "build-storybook && percy-storybook --widths=320,414,768,1280 --debug",
     "start": "start-storybook -p 9001 -c .storybook",
     "test": "eslint src stories --max-warnings=0",
     "dev": "babel src/ -w -d lib/"


### PR DESCRIPTION
#### Please tick a box ###
- [x] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)

Take snapshots to send to Percy at 320, 414, 768, 1280.
414 and 768 are the new widths.

#### Users by screen width, dagbladet.no ####
```
320x  ~10%
360x  ~17%
375x  ~25%
414x   ~5%
768x  ~12%
1280x  ~5%
1366x  ~4%
1920x  ~8%
```