### PR TITLE
refactor: Have media queries use flexboxgrid breakpoints

### DIFF
--- a/src/LargeScreenText.jsx
+++ b/src/LargeScreenText.jsx
@@ -1,9 +1,10 @@
 import styled from 'styled-components';
+import { smallUp } from './utils/media-queries';
 
 const LargeScreenText = styled.span`
 	display: none;
 
-	@media (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media ${smallUp} {
 		display: inline;
 	}
 `;

--- a/src/atoms/DontPushTheAdBoundaries.js
+++ b/src/atoms/DontPushTheAdBoundaries.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { smallUp } from '../utils/media-queries';
 
 const DontPushTheAdBoundaries = styled.div`
 	display: flex;
@@ -7,7 +8,7 @@ const DontPushTheAdBoundaries = styled.div`
 	box-orient: vertical; /* ios8.x really, really needs this; overrides flex direction */
 	padding: calc(${props => props.theme.variables.verticalBase}/2) 0 0;
 
-	@media (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media ${smallUp} {
 		position: relative;
 		width: 100%;
 		max-width: 100.0rem;

--- a/src/atoms/FrontHeading.js
+++ b/src/atoms/FrontHeading.js
@@ -1,4 +1,6 @@
 import { css } from 'styled-components';
+import { smallUp } from '../utils/media-queries';
+
 import {
 	SmallHeading,
 	MediumHeading,
@@ -27,13 +29,13 @@ const FheadStyle = props => css`
 
 export const FrontSmallHeading = SmallHeading.extend`
 	${FheadStyle}
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media ${smallUp}) {
 		font-size: ${props => props.theme.variables.headingSmallSize};
 	}
 `;
 export const FrontMediumHeading = MediumHeading.extend`
 	${FheadStyle}
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media ${smallUp} {
 		font-size: ${props => props.theme.variables.headingMediumSize};
 	}
 `;

--- a/src/atoms/Heading.js
+++ b/src/atoms/Heading.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import styled, { css } from 'styled-components';
+import { smallUp } from '../utils/media-queries';
 
 const ProtoHeading = styled.h1`
 	padding: 0;
@@ -41,7 +42,7 @@ const getSizes = ({ size, marginTopFactor, marginBottomFactor }) => {
 const SmallHeading = ProtoHeading.extend`
 	${props => getSizes({ size: 'small', ...props })}
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media ${smallUp} {
 		${props => getSizes({ size: 'regular', ...props })}
  	}
 `;
@@ -49,7 +50,7 @@ const SmallHeading = ProtoHeading.extend`
 const MediumHeading = ProtoHeading.extend`
 	${props => getSizes({ size: 'medium', ...props })}
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media ${smallUp} {
 		${props => getSizes({ size: 'regular', ...props })}
 	}
 `;
@@ -57,7 +58,7 @@ const MediumHeading = ProtoHeading.extend`
 const LargeHeading = ProtoHeading.extend`
 	${props => getSizes({ size: 'regular', ...props })}
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media ${smallUp} {
 		${props => getSizes({ size: 'large', ...props })}
 	}
 `;
@@ -65,7 +66,7 @@ const LargeHeading = ProtoHeading.extend`
 const XLargeHeading = ProtoHeading.extend`
 	${props => getSizes({ size: 'regular', ...props })}
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media ${smallUp} {
 		${props => getSizes({ size: 'xlarge', ...props })}
 	}
 `;
@@ -73,7 +74,7 @@ const XLargeHeading = ProtoHeading.extend`
 const HugeHeading = ProtoHeading.extend`
 	${props => getSizes({ size: 'large', ...props })}
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media ${smallUp} {
 		${props => getSizes({ size: 'huge', ...props })}
 	}
 `;

--- a/src/atoms/LinkBarLinkBase.js
+++ b/src/atoms/LinkBarLinkBase.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { smallUp } from '../utils/media-queries';
 
 const getTextColor = ({
 	theme, isActive, activeTextColor, textColor,
@@ -94,7 +95,7 @@ export const LinkBarLinkBase = styled.a`
 		transition: width .2s ease-in-out;
 	}
 
-	@media (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media ${smallUp} {
 		${(props) => {
 		if (props.size === 'xsmall') {
 			return css`

--- a/src/atoms/MainRecipe/ColorTextBox.js
+++ b/src/atoms/MainRecipe/ColorTextBox.js
@@ -16,6 +16,7 @@ const ColorTextBox = styled(Col)`
 	color: ${props => props.theme.colors[props.textColor]};
 	background-color: ${props => props.theme.colors[props.bgColor]};
 
+	/* TODO Rewrite this this piece of code to mobile first */
 	@media screen and (max-width: ${props => props.theme.flexboxgrid.breakpoints.md}em) {
 		padding: 9rem 16rem;
 		font-size: 5rem;

--- a/src/atoms/MainRecipe/MoreLine.js
+++ b/src/atoms/MainRecipe/MoreLine.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { MediumHeading } from '../Heading';
 import { SvgIcon } from '../SvgIcon';
 
+// @TODO: Rewrite this piece of code to have mobile first styles
 const MoreStyle = styled.div`
 	text-align: center;
 	text-transform: uppercase;
@@ -10,8 +11,8 @@ const MoreStyle = styled.div`
 	cursor: pointer;
 	@media screen and (max-width: ${props => props.theme.flexboxgrid.breakpoints.md}em) {
 		width: 16rem;
-	} 
-	
+	}
+
 	& h1 {
 		margin-bottom: 0.5rem;
 		@media screen and (max-width: ${props => props.theme.flexboxgrid.breakpoints.md}em) {
@@ -19,7 +20,7 @@ const MoreStyle = styled.div`
 			font-size: 3.5rem;
 		}
 	}
-	
+
 	& .icon-wrapper {
 		width: 100%;
 	}

--- a/src/atoms/SvgIcon/SvgIconWrapper.js
+++ b/src/atoms/SvgIcon/SvgIconWrapper.js
@@ -1,17 +1,18 @@
-import Styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { smallUp } from '../../utils/media-queries';
 
-const SvgIconWrapper = Styled.div`
+// @TODO: Rewrite this piece of code to have mobile first styles
+const SvgIconWrapper = styled.div`
 	display: inline-block;
 	text-align: center;
 	width: ${(props) => {
 		return props.size;
 	}}rem;
-	
-	${props => (props['size-sm'] && `
-	@media screen 
-	and (max-width: ${props.theme.flexboxgrid.breakpoints.md}em) {
-		width: ${props['size-sm']}rem;
- 	}
+
+	${props => (props['size-sm'] && css`
+		@media screen	and (max-width: ${props.theme.flexboxgrid.breakpoints.md}em) {
+			width: ${props['size-sm']}rem;
+	 	}
  	`)}
 `;
 

--- a/src/atoms/SvgIcon/SvgIconWrapper.js
+++ b/src/atoms/SvgIcon/SvgIconWrapper.js
@@ -1,5 +1,4 @@
 import styled, { css } from 'styled-components';
-import { smallUp } from '../../utils/media-queries';
 
 // @TODO: Rewrite this piece of code to have mobile first styles
 const SvgIconWrapper = styled.div`

--- a/src/atoms/UnderlinedHeading.js
+++ b/src/atoms/UnderlinedHeading.js
@@ -14,6 +14,8 @@ const StyledLine = styled.div`
 	margin-left: auto;
 	margin-right: auto;
 	${props => props.thick && css`border-width: .2rem`}
+
+	/* @TODO: Rewrite these styles to be mobile first*/
 	@media only screen
 	 and (min-width: ${props => props.theme.flexboxgrid.breakpoints.xs}em)
 	 and (max-width: ${props => props.theme.flexboxgrid.breakpoints.md}em) {

--- a/src/molecules/Footers/OppskriftFooter.js
+++ b/src/molecules/Footers/OppskriftFooter.js
@@ -15,7 +15,7 @@ const FooterWrapper = styled.footer`
 	@media screen and (min-width: ${props => props.theme.flexboxgrid.breakpoints.md}em) {
 		padding: 10rem 0 6rem;
 	}
-	
+
 	.text-left{
 		text-align: left;
 	}

--- a/src/molecules/MainRecipe/RecipeMetaData.js
+++ b/src/molecules/MainRecipe/RecipeMetaData.js
@@ -17,6 +17,8 @@ import { BylineWithTwoLines } from '../../atoms/BylineWithTwoLines';
 const RecipeMetaDataWrapper = styled.div`
 	padding: 0;
 	margin: 0 auto;
+
+	/* @TODO Rewrite these styles to be mobile first */
 	@media screen and (min-width: ${props => props.theme.variables.mediumWidth}) {
 		padding: 1% 10%;
 	}

--- a/src/utils/hide-with-flexboxgrid-syntax.js
+++ b/src/utils/hide-with-flexboxgrid-syntax.js
@@ -1,3 +1,6 @@
+import { css } from 'styled-components';
+import { extraSmallUp, smallUp, mediumUp, largeUp } from './media-queries';
+
 /**
  * Hide a styled-component with syntax familiar to users of react-styled-flexboxgrid.
  *
@@ -11,27 +14,23 @@
  *   md: null,
  *   lg: null,
  * }
+ *
+ * <Foo xs>
+ * <Foo xs={false} md />
  */
 const hideWithFlexboxgridSyntax = (display) => {
 	return (props) => {
 		const {
 			xs, sm, md, lg,
-			theme: {
-				flexboxgrid: {
-					breakpoints: {
-						xs: xsBreak, sm: smBreak, md: mdBreak, lg: lgBreak,
-					},
-				},
-			},
 		} = props;
 
 		const acc = [];
 
 		acc.push(`display: ${display};`);
-		xs !== null && acc.push(`@media only screen and (min-width: ${xsBreak}em) { display: ${xs ? display : 'none'}}`);
-		sm !== null && acc.push(`@media only screen and (min-width: ${smBreak}em) { display: ${sm ? display : 'none'}}`);
-		md !== null && acc.push(`@media only screen and (min-width: ${mdBreak}em) { display: ${md ? display : 'none'}}`);
-		lg !== null && acc.push(`@media only screen and (min-width: ${lgBreak}em) { display: ${lg ? display : 'none'}}`);
+		xs !== null && acc.push(css`@media ${extraSmallUp} { display: ${xs ? display : 'none'}}`);
+		sm !== null && acc.push(css`@media ${smallUp}      { display: ${sm ? display : 'none'}}`);
+		md !== null && acc.push(css`@media ${mediumUp}     { display: ${md ? display : 'none'}}`);
+		lg !== null && acc.push(css`@media ${largeUp}      { display: ${lg ? display : 'none'}}`);
 
 		return acc.join('\n');
 	};

--- a/src/utils/media-queries.js
+++ b/src/utils/media-queries.js
@@ -1,21 +1,6 @@
 import { css } from 'styled-components';
 
-const sizes = {
-	xlarge: 1920,
-	large: 1440,
-	medium: 1024,
-	small: 640,
-};
-
-// iterate through the sizes and create a media template
-export const media = Object.keys(sizes).reduce((accumulator, label) => {
-	// use em in breakpoints to work properly cross-browser and support users
-	// changing their browsers font-size: https://zellwk.com/blog/media-query-units/
-	const emSize = sizes[label] / 16;
-	accumulator[label] = (...args) => css`
-	  @media (max-width: ${emSize}em) {
-		 ${css(...args)}
-	  }
-	`;
-	return accumulator;
-}, {});
+export const extraSmallUp = css`(min-width: ${props => props.theme.flexboxgrid.breakpoints.xs}em)`;
+export const smallUp = css`(min-width: ${props => props.theme.flexboxgrid.breakpoints.sm}em)`;
+export const mediumUp = css`(min-width: ${props => props.theme.flexboxgrid.breakpoints.md}em)`;
+export const largeUp = css`(min-width: ${props => props.theme.flexboxgrid.breakpoints.lg}em)`;

--- a/stories/link-bars/MatStory.js
+++ b/stories/link-bars/MatStory.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { smallUp } from '../../src/utils/media-queries';
+
 import {
 	LinkBarLink,
 	XSmallLinkBarLink,
@@ -22,7 +24,8 @@ const LogoLink = styled(XSmallLinkBarLink)`
 	position: absolute;
 	top:0;
 	width: 10.6rem;
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+
+	@media ${smallUp} {
 		width: 14.6rem;
 	}
 `;

--- a/stories/link-bars/SeHerStory.js
+++ b/stories/link-bars/SeHerStory.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { smallUp } from '../../src/utils/media-queries';
+
 import {
 	LinkBarLink,
 	XSmallLinkBarLink,
@@ -20,7 +22,7 @@ const LogoLink = styled(XSmallLinkBarLink)`
 	width: calc(2.5 * ${props => props.theme.variables.verticalBase});
 	transition: .2s width;
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media ${smallUp}) {
 		width: calc(4 * ${props => props.theme.variables.verticalBase} + 1.1rem);
 	}
 `;


### PR DESCRIPTION
#### Please tick a box ###
- [x] **refactor** _(A code change that neither fixes a bug nor adds a feature_)

#### If you're adding a feature, is it documented in a storybook story?
- [ ] Yes
- [ ] No

#### Are the components you're working on reusable between brands?
- [x] Yes _(Using variables that are defined in the default theme)_

#### If you're creating markup, did you add proper semantics? 
- [x] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
