### PR TITLE
ci: Use 9 instead of stable node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "node"
+  - "9"
   - "8"
 
 before_install:
@@ -12,7 +12,7 @@ before_script:
 
 script:
   - |
-    if [[ $TRAVIS_PULL_REQUEST != "false" ]] && [[ $TRAVIS_NODE_VERSION == "node" ]]; then
+    if [[ $TRAVIS_PULL_REQUEST != "false" ]] && [[ $TRAVIS_NODE_VERSION == "9" ]]; then
       echo "Sending PR snapshots to Percy";
       npm run snapshot;
     elif [[ $TRAVIS_PULL_REQUEST == "false" ]] && [[ $TRAVIS_BRANCH == "master" ]] && [[ $TRAVIS_NODE_VERSION == "node" ]]; then


### PR DESCRIPTION
We indirectly depend on anodynos/upath via webpack. upath specifically states it does not support node > 9.

Stable should be added back in as soon as our dependency graph has updated to address this – hopefully it will not be too long.

See anodynos/upath#14
See anodynos/upath#15

#### Please tick a box ###
- [x] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)

#### If you're adding a feature, is it documented in a storybook story?
- [x] Not applicable

#### Are the components you're working on reusable between brands?
- [x] Not applicable

#### If you're creating markup, did you add proper semantics? 
- [x] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
