### PR TITLE
fix: Stop loading other sites' fonts

### DIFF
--- a/src/themes/dagbladet/index.js
+++ b/src/themes/dagbladet/index.js
@@ -1,4 +1,3 @@
-import { css } from 'styled-components';
 import colors from './colors';
 
 const variables = {
@@ -6,7 +5,7 @@ const variables = {
 	headingsFont: '"Roboto","Helvetica",Helvetica,Arial,sans-serif',
 };
 
-const global = css`
+const global = `
 	@import url('https://fonts.googleapis.com/css?family=Roboto:300,700,800');
 
 	* {

--- a/src/themes/default-theme/index.js
+++ b/src/themes/default-theme/index.js
@@ -1,9 +1,8 @@
-import { css } from 'styled-components';
 import variables from './variables';
 import colors from './colors';
 import flexboxgrid from './flexboxgrid';
 
-const global = css`
+const global = `
 	* {
 		box-sizing: border-box;
 	}

--- a/src/themes/dinside/index.js
+++ b/src/themes/dinside/index.js
@@ -1,4 +1,3 @@
-import { css } from 'styled-components';
 import colors from './colors';
 
 const variables = {
@@ -6,7 +5,7 @@ const variables = {
 	headingsFont: "'Open Sans', helvetica, arial, sans-serif",
 };
 
-const global = css`
+const global = `
 	@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,700,800');
 
 	* {

--- a/src/themes/kk/index.js
+++ b/src/themes/kk/index.js
@@ -1,4 +1,3 @@
-import { css } from 'styled-components';
 import colors from './colors';
 import { fontSpecs } from './font-specs';
 
@@ -7,7 +6,7 @@ const variables = {
 	headingsFont: '"Didot 16 A", "Didot 16 B", Didot, "GFS Didot", Georgia, serif',
 };
 
-const global = css`
+const global = `
 	${fontSpecs}
 
 	* {

--- a/src/themes/mat/index.js
+++ b/src/themes/mat/index.js
@@ -1,9 +1,8 @@
-import { css } from 'styled-components';
 import { stripUnit } from 'polished';
 import colors from './colors';
 import variables from './variables';
 
-const global = css`
+const global = `
 	@import url('https://fonts.googleapis.com/css?family=Ubuntu|Cabin:400,700');
 
 	* {

--- a/src/themes/seher/index.js
+++ b/src/themes/seher/index.js
@@ -1,4 +1,3 @@
-import { css } from 'styled-components';
 import { darken, lighten } from 'polished';
 import { variables } from './variables';
 
@@ -21,7 +20,7 @@ const shadedColors = Object.keys(colorsToShade).map(color => ({
 
 const combinedShadedColors = shadedColors.reduce((acc, cur) => Object.assign(acc, cur), {});
 
-const global = css`
+const global = `
 	@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,800');
 
 	* {

--- a/src/themes/sol/index.js
+++ b/src/themes/sol/index.js
@@ -1,11 +1,9 @@
-import { css } from 'styled-components';
-
 import colors from './colors';
 import variables from './variables';
 
 // TODO: A pemanent solution for the a underline should be made.
 //       se: https://github.com/dbmedialab/wolverine-frontend/issues/460
-const global = css`
+const global = `
 	@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,700,800');
 
 	* {


### PR DESCRIPTION
Make theme.global a literal instead of an array; fixes bug that loads multiple fonts

#### Please tick a box ###
- [ ] **feature** _(A new feature_)
- [ ] **fix** _(A bug fix_)
- [ ] **refactor** _(A code change that neither fixes a bug nor adds a feature_)
- [ ] **docs** _(Documentation only changes_)
- [ ] **performance** _(A code change that improves performance_)
- [ ] **style** _(Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)_)
- [ ] **build** _(Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)_)
- [ ] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)
- [ ] **test** _(Adding missing tests or correcting existing tests_)

#### If you're adding a feature, is it documented in a storybook story?
- [ ] Yes
- [ ] No
- [ ] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [ ] Yes _(Using variables that are defined in the default theme)_
- [ ] No _(I hard coded some values)_
- [ ] Not working on any components

#### If you're creating markup, did you add proper semantics? 
- [ ] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [ ] I added microdata from [Schema.org](http://schema.org/)
- [ ] Semantics are derived from HTML
- [ ] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
