### PR TITLE
refactor: Use getColor and getVariable in all files using the type color

### DIFF
--- a/src/atoms/BylineWithTwoLines.js
+++ b/src/atoms/BylineWithTwoLines.js
@@ -1,6 +1,9 @@
 import Styled from 'styled-components';
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import { getColor, getVariable } from '../utils';
+
 import { SvgIcon } from './SvgIcon';
 
 const BylineBlock = Styled.div`
@@ -13,7 +16,7 @@ const BylineImage = Styled.img.attrs({
     height: 4.5rem;
     overflow: hidden;
     border-radius: 50%;
-    margin-right: ${props => props.theme.variables.horizontalBase};
+    margin-right: ${getVariable('horizontalBase')};
 `;
 
 const WrapAvatar = Styled.div`
@@ -22,28 +25,28 @@ const WrapAvatar = Styled.div`
     height: 4.5rem;
     overflow: hidden;
     border-radius: 50%;
-    margin-right: ${props => props.theme.variables.horizontalBase};
+    margin-right: ${getVariable('horizontalBase')};
     text-align: center;
 `;
 
 const TextBlock = Styled.div`
     float: left;
-    color: ${props => props.theme.colors.type};
-    font-family: ${props => props.theme.variables.mainFont};
+    color: ${getColor('type')};
+    font-family: ${getVariable('mainFont')};
 `;
 
 const Name = Styled.div`
-    font-size: ${props => props.theme.variables.uiRegularSize};
-    line-height: ${props => props.theme.variables.uiRegularLineHeight};
+    font-size: ${getVariable('uiRegularSize')};
+    line-height: ${getVariable('uiRegularLineHeight')};
     font-weight: 300;
 `;
 
 const Email = Styled.a.attrs({
 	href: ({ email }) => `mailto:${email}`,
 })`
-    font-size: ${props => props.theme.variables.uiSmallSize};
+    font-size: ${getVariable('uiSmallSize')};
     font-weight: 300;
-    color: ${props => props.theme.colors.type};
+    color: ${getColor('type')};
 `;
 
 const BylineWithTwoLines = ({ src, name, email }) => (

--- a/src/atoms/ColorBox.js
+++ b/src/atoms/ColorBox.js
@@ -1,20 +1,21 @@
 import React from 'react';
 import propTypes from 'prop-types';
-
 import styled from 'styled-components';
+
+import { getColor } from '../utils';
 
 const ColorDiv = styled.div`
 	flex: ${props => (props.isMainShade ? '9 1 20%' : '1 1 20%')};
 	padding: 2.4rem 1.4rem;
-	background-color: ${props => props.theme.colors[`${props.displayColor}`]};
+	background-color: ${props => getColor(props.displayColor)};
 	color: ${props => (props.textColor === 'light'
-		? props.theme.colors.white
-		: props.theme.colors.type
+		? getColor('white')
+		: getColor('type')
 	)};
 	text-align: center;
 
 	&::after {
-		content: '${props => props.theme.colors[`${props.displayColor}`]}';
+		content: '${props => getColor(props.displayColor)}';
 	}
 `;
 

--- a/src/atoms/Heading.js
+++ b/src/atoms/Heading.js
@@ -2,11 +2,13 @@ import React from 'react';
 import propTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
+import { getColor, getVariable } from '../utils';
+
 const ProtoHeading = styled.h1`
 	padding: 0;
-	color: ${props => props.theme.colors.type};
+	color: ${getColor('type')};
 	font-weight: 700;
-	font-family: ${props => props.theme.variables.headingsFont};
+	font-family: ${getVariable('headingsFont')};
 
 	${props => props.ALLCAPS && css`
 		text-transform: uppercase;
@@ -28,12 +30,12 @@ ProtoHeading.defaultProps = {
 const getSizes = ({ size, marginTopFactor, marginBottomFactor }) => {
 	const capSize = size.slice(0, 1).toUpperCase() + size.slice(1);
 	return css`
-		font-size: ${props => props.theme.variables[`heading${capSize}Size`]};
-		line-height: ${props => props.theme.variables[`heading${capSize}LineHeight`]};
+		font-size: ${getVariable(`heading${capSize}Size`)};
+		line-height: ${getVariable(`heading${capSize}LineHeight`)};
 		margin:
-			calc(${marginTopFactor} * ${props => props.theme.variables[`heading${capSize}LineHeight`]})
+			calc(${marginTopFactor} * ${getVariable(`heading${capSize}LineHeight`)})
 			0
-			calc(${marginBottomFactor} * ${props => props.theme.variables[`heading${capSize}LineHeight`]})
+			calc(${marginBottomFactor} * ${getVariable(`heading${capSize}LineHeight`)})
 		;
 	`;
 };
@@ -41,7 +43,7 @@ const getSizes = ({ size, marginTopFactor, marginBottomFactor }) => {
 const XSmallHeading = ProtoHeading.extend`
 	${props => getSizes({ size: 'small', ...props })}
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media screen and (min-width: ${getVariable('largeWidth')}) {
 		${props => getSizes({ size: 'medium', ...props })}
  	}
 `;
@@ -49,7 +51,7 @@ const XSmallHeading = ProtoHeading.extend`
 const SmallHeading = ProtoHeading.extend`
 	${props => getSizes({ size: 'small', ...props })}
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media screen and (min-width: ${getVariable('largeWidth')}) {
 		${props => getSizes({ size: 'regular', ...props })}
  	}
 `;
@@ -57,7 +59,7 @@ const SmallHeading = ProtoHeading.extend`
 const MediumHeading = ProtoHeading.extend`
 	${props => getSizes({ size: 'medium', ...props })}
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media screen and (min-width: ${getVariable('largeWidth')}) {
 		${props => getSizes({ size: 'regular', ...props })}
 	}
 `;
@@ -65,7 +67,7 @@ const MediumHeading = ProtoHeading.extend`
 const LargeHeading = ProtoHeading.extend`
 	${props => getSizes({ size: 'regular', ...props })}
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media screen and (min-width: ${getVariable('largeWidth')}) {
 		${props => getSizes({ size: 'large', ...props })}
 	}
 `;
@@ -73,7 +75,7 @@ const LargeHeading = ProtoHeading.extend`
 const XLargeHeading = ProtoHeading.extend`
 	${props => getSizes({ size: 'regular', ...props })}
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media screen and (min-width: ${getVariable('largeWidth')}) {
 		${props => getSizes({ size: 'xlarge', ...props })}
 	}
 `;
@@ -81,7 +83,7 @@ const XLargeHeading = ProtoHeading.extend`
 const HugeHeading = ProtoHeading.extend`
 	${props => getSizes({ size: 'large', ...props })}
 
-	@media screen and (min-width: ${props => props.theme.variables.largeWidth}) {
+	@media screen and (min-width: ${getVariable('largeWidth')}) {
 		${props => getSizes({ size: 'huge', ...props })}
 	}
 `;

--- a/src/atoms/MainRecipe/Quantity.js
+++ b/src/atoms/MainRecipe/Quantity.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
+import { getColor } from '../../utils';
+
 import { Col } from '../../atoms/Col';
 import { Row } from '../../atoms/Row';
 
@@ -17,7 +19,7 @@ const BoldCol = Col.extend`
 	font-weight: bold;
 	& a {
 		text-decoration: none;
-		color: ${props => props.theme.colors.type}
+		color: ${getColor('type')}
 	}
 `;
 

--- a/src/atoms/PublishedDate.js
+++ b/src/atoms/PublishedDate.js
@@ -1,15 +1,17 @@
 import styled from 'styled-components';
 
+import { getColor } from '../utils';
+
 const PublishedDate = styled.span`
 	display: ${props => (props.hide && 'none') || 'inline-block'};
-	color: ${props => props.theme.colors[props.color] || props.theme.colors.typeLight};
+	color: ${props => getColor(props.color)};
 	font-size: 1.1rem;
 	letter-spacing: 0.1em;
 	text-transform: uppercase;
 `;
 
 PublishedDate.defaultProps = {
-	colors: 'typeLight',
+	color: 'typeLight',
 };
 
 export { PublishedDate };

--- a/src/atoms/loaders/DotLoader.js
+++ b/src/atoms/loaders/DotLoader.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { getColor } from '../../utils';
+
 const DotLoaderContainer = styled.div`
 	height: 6.5rem;
 
@@ -24,7 +26,7 @@ const DotLoader = styled.div`
 	margin: 0 auto;
 	transform: translateZ( 0 );
 	border-radius: 50%;
-	color: ${props => props.theme.colors.typeDisabled};
+	color: ${getColor('typeDisabled')};
 	font-size: 1.0rem;
 	text-indent: -9999em;
 	content: '';

--- a/src/molecules/Footers/OppskriftFooter.js
+++ b/src/molecules/Footers/OppskriftFooter.js
@@ -1,21 +1,22 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { getColor, getVariable } from '../../utils';
 import { Col, Row, Grid } from '../..';
 import { SvgIcon } from '../../atoms/SvgIcon';
 
 const FooterWrapper = styled.footer`
-	background-color: ${props => props.theme.colors.type};
-	color: ${props => props.theme.colors.white};
-	font-family: ${props => props.theme.variables.mainFont};
-	font-size: ${props => props.theme.variables.headingSmallSize};
-	line-height: ${props => props.theme.variables.headingSmallLineHeight};
+	background-color: ${getColor('type')};
+	color: ${getColor('white')};
+	font-family: ${getVariable('mainFont')};
+	font-size: ${getVariable('headingSmallSize')};
+	line-height: ${getVariable('headingSmallLineHeight')};
 	padding: 5rem 2rem 4rem;
 
 	@media screen and (min-width: ${props => props.theme.flexboxgrid.breakpoints.md}em) {
 		padding: 10rem 0 6rem;
 	}
-	
+
 	.text-left{
 		text-align: left;
 	}
@@ -39,8 +40,8 @@ const OppskriftLink = styled.a`
 	text-decoration: none;
 	color: inherit;
 	font-family: 'Ubuntu', sans-serif;
-	font-size: ${props => props.theme.variables.headingLargeSize};
-	line-height: ${props => props.theme.variables.headingLargeLineHeight};
+	font-size: ${getVariable('headingLargeSize')};
+	line-height: ${getVariable('headingLargeLineHeight')};
 	&::after {
 		content: '';
 		display: block;


### PR DESCRIPTION
This prepares for moving the type color from directly on the colors object to the skinColors object.

#### Please tick a box ###
- [x] **refactor** _(A code change that neither fixes a bug nor adds a feature_)

#### If you're adding a feature, is it documented in a storybook story?
- [x] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [x] Yes _(Using variables that are defined in the default theme)_

#### If you're creating markup, did you add proper semantics? 
- [x] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
