### PR TITLE
Ignore Code.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "snapshot": "build-storybook && percy-storybook --widths=320,414,768,1280 --debug",
     "start": "start-storybook -p 9001 -c .storybook",
     "test": "eslint src stories --max-warnings=0",
-    "dev": "babel src/ -w -d lib/ ---ignore Code.js"
+    "dev": "babel src/ -w -d lib/ --ignore Code.js"
   },
   "author": "Aller Media",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "snapshot": "build-storybook && percy-storybook --widths=320,414,768,1280 --debug",
     "start": "start-storybook -p 9001 -c .storybook",
     "test": "eslint src stories --max-warnings=0",
-    "dev": "babel src/ -w -d lib/"
+    "dev": "babel src/ -w -d lib/ ---ignore Code.js"
   },
   "author": "Aller Media",
   "license": "ISC",


### PR DESCRIPTION
It has a referance to a css files that forces the clients to have a css loader in their webpack config, but it is only used internally by shiny

#### Please tick a box ###
- [x ] **fix** _(A bug fix_)
