### PR TITLE
feature: Add full-grown reset styles to most themes

### DIFF
--- a/src/atoms/Code.js
+++ b/src/atoms/Code.js
@@ -2,9 +2,9 @@
 
 import { default as React } from 'react';
 import { default as PropTypes } from 'prop-types';
+import styled from 'styled-components';
 
 import Prism from '@maji/react-prism';
-
 import 'prismjs';
 
 // Other than javascript, we'll have to import
@@ -17,17 +17,25 @@ import 'prismjs/components/prism-jsx';
 
 import 'prism-themes/themes/prism-hopscotch.css';
 
+import { getVariable } from '../utils';
+
+const PrismStyles = styled.div`
+	&& pre {
+		margin: 0 0 ${getVariable('verticalBase')};
+	}
+`;
+
 const Code = ({
 	language,
 	children,
 	...rest
-}) => {
-	return (
+}) => (
+	<PrismStyles>
 		<Prism language={language} {...rest}>
 			{children}
 		</Prism>
-	);
-};
+	</PrismStyles>
+);
 Code.propTypes = {
 	children: PropTypes.node,
 	language: PropTypes.string,

--- a/src/atoms/ShinyThemeProvider.js
+++ b/src/atoms/ShinyThemeProvider.js
@@ -1,28 +1,12 @@
 /* eslint-disable max-len */
 import React from 'react';
 import propTypes from 'prop-types';
-import { ThemeProvider as StyledComponentsThemeProvider, injectGlobal, css } from 'styled-components';
+import { ThemeProvider as StyledComponentsThemeProvider, injectGlobal } from 'styled-components';
 import { merge } from 'aurora-deep-slice-merge';
 
 import defaultTheme from '../themes/default-theme';
 import { themePropTypes } from '../themes/theme-prop-types';
 
-// @TODO: Switch to a proper CSS reset, like this one in utils:
-// import { cssReset } from '../utils';
-const cssReset = css`
-	/* Font reset: 1rem = 10px */
-	html {
-		font-size: 62.5%;
-	}
-	body {
-		font-size: 1.6rem;
-	}
-	/* HTML5 display-role reset for older browsers */
-	article, aside, details, figcaption, figure,
-	footer, header, hgroup, menu, nav, section, main {
-    	display: block;
-	}
-`;
 /**
  * An extension of styled-component's ThemeProvider.
  *
@@ -41,13 +25,8 @@ const ShinyThemeProvider = ({ children, theme }) => {
 	// console.log(`Switching to the ${themeName} theme.`);
 	// console.log('new theme', theme.name);
 
-	// Inject
-	// - Reset styles
-	// - Our theme's global styles
-	injectGlobal`
-		${cssReset}
-		${mergedTheme.global}
-	`;
+	// Inject our theme's global styles
+	injectGlobal`${mergedTheme.global}`;
 
 	/**
 	 * TODO: Make that inner div a React.Fragment
@@ -63,7 +42,7 @@ const ShinyThemeProvider = ({ children, theme }) => {
 	);
 };
 ShinyThemeProvider.propTypes = {
-	theme: themePropTypes,
+	theme: propTypes.shape(themePropTypes),
 	children: propTypes.oneOfType([
 		propTypes.arrayOf(propTypes.node),
 		propTypes.node,

--- a/src/themes/dagbladet/index.js
+++ b/src/themes/dagbladet/index.js
@@ -1,27 +1,27 @@
+import { cssReset } from '../../utils/css-reset';
+
 import colors from './colors';
 
 const variables = {
 	mainFont: '"Roboto","Helvetica",Helvetica,Arial,sans-serif',
 	headingsFont: '"Roboto","Helvetica",Helvetica,Arial,sans-serif',
+
+	uiRegularSize: '1.6rem',
+	uiRegularLineHeight: '2.4rem',
 };
 
 const global = `
 	@import url('https://fonts.googleapis.com/css?family=Roboto:300,700,800');
 
-	* {
-		box-sizing: border-box;
-	}
+	${cssReset}
 
 	body {
-		color: #222;
-		padding: 0;
-		margin: 0;
+		color: ${colors[colors.skinColors.type]};
 		font-family: ${variables.mainFont};
+		font-size: ${variables.uiRegularSize};
+		line-height: ${variables.uiRegularLineHeight};
+
 		font-weight: 300;
-		font-style: normal;
-		line-height: 1.5;
-		position: relative;
-		cursor: auto;
 	}
 `;
 

--- a/src/themes/default-theme/index.js
+++ b/src/themes/default-theme/index.js
@@ -2,21 +2,40 @@ import variables from './variables';
 import colors from './colors';
 import flexboxgrid from './flexboxgrid';
 
-const global = `
-	* {
-		box-sizing: border-box;
+// @TODO: Switch to a proper CSS reset, like this one in utils:
+// import { cssReset } from '../utils';
+const cssReset = `
+	/* Font reset: 1rem = 10px */
+	html {
+		font-size: 62.5%;
+	}
+	body {
+		font-size: 1.6rem;
 	}
 
-	body {
-		color: #222;
-		padding: 0;
+	html, body {
 		margin: 0;
+		padding: 0;
+	}
+
+	* { box-sizing: border-box; }
+
+	/* HTML5 display-role reset for older browsers */
+	article, aside, details, figcaption, figure,
+	footer, header, hgroup, menu, nav, section, main {
+    	display: block;
+	}
+`;
+
+const global = `
+	${cssReset}
+
+	body {
+		color: ${colors[colors.skinColors.type]};
 		font-family: ${variables.mainFont};
+		font-size: ${variables.uiRegularSize};
+		line-height: ${variables.uiRegularLineHeight};
 		font-weight: 300;
-		font-style: normal;
-		line-height: 1.5;
-		position: relative;
-		cursor: auto;
 	}
 `;
 

--- a/src/themes/dinside/index.js
+++ b/src/themes/dinside/index.js
@@ -1,29 +1,26 @@
+import { cssReset } from '../../utils/css-reset';
+
 import colors from './colors';
 
 const variables = {
 	mainFont: "'Open Sans', helvetica, arial, sans-serif",
 	headingsFont: "'Open Sans', helvetica, arial, sans-serif",
 
-	uiRegularLineHeight: '1.5',
+	uiRegularSize: '1.6rem',
+	uiRegularLineHeight: '2.4rem',
 };
 
 const global = `
 	@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,700,800');
 
-	* {
-		box-sizing: border-box;
-	}
+	${cssReset}
 
 	body {
-		color: #333;
-		padding: 0;
-		margin: 0;
+		color: ${colors[colors.skinColors.type]};
 		font-family: ${variables.mainFont};
 		font-weight: 400;
-		font-style: normal;
+		font-size: ${variables.uiRegularSize};
 		line-height: ${variables.uiRegularLineHeight};
-		position: relative;
-		cursor: auto;
 	}
 
 	a {

--- a/src/themes/kk/index.js
+++ b/src/themes/kk/index.js
@@ -1,28 +1,27 @@
+import { cssReset } from '../../utils/css-reset';
+
 import colors from './colors';
 import { fontSpecs } from './font-specs';
 
 const variables = {
 	mainFont: '"Open Sans", Helvetica, Arial, sans-serif',
 	headingsFont: '"Didot 16 A", "Didot 16 B", Didot, "GFS Didot", Georgia, serif',
+
+	uiRegularSize: '1.6rem',
+	uiRegularLineHeight: '2.4rem',
 };
 
 const global = `
 	${fontSpecs}
 
-	* {
-		box-sizing: border-box;
-	}
+	${cssReset}
 
 	body {
-		color: #222;
-		padding: 0;
-		margin: 0;
+		color: ${colors[colors.skinColors.type]};
 		font-family: ${variables.mainFont};
+		font-size: ${variables.uiRegularSize};
+		line-height: ${variables.uiRegularLineHeight};
 		font-weight: 300;
-		font-style: normal;
-		line-height: 1.5;
-		position: relative;
-		cursor: auto;
 	}
 `;
 

--- a/src/themes/light-theme/index.js
+++ b/src/themes/light-theme/index.js
@@ -1,9 +1,14 @@
 import { darken, lighten } from 'polished';
 
+import { cssReset } from '../../utils/css-reset';
+
 const variables = {
 	mainFont: '"Roboto","Helvetica",Helvetica,Arial,sans-serif',
 	headingsFont: '"Roboto","Helvetica",Helvetica,Arial,sans-serif',
 	headingsWeight: '300',
+
+	uiRegularSize: '1.6rem',
+	uiRegularLineHeight: '2.4rem',
 };
 
 const colorsToShade = {
@@ -59,20 +64,14 @@ const colors = {
 const global = `
 	@import url('https://fonts.googleapis.com/css?family=Roboto:300,700,800');
 
-	* {
-		box-sizing: border-box;
-	}
+	${cssReset}
 
 	body {
-		color: ${colors.type}
-		padding: 0;
-		margin: 0;
+		color: ${colors[colors.skinColors.type]};
 		font-family: ${variables.mainFont};
+		font-size: ${variables.uiRegularSize};
+		line-height: ${variables.uiRegularLineHeight};
 		font-weight: 300;
-		font-style: normal;
-		line-height: 1.5;
-		position: relative;
-		cursor: auto;
 	}
 `;
 

--- a/src/themes/mat/index.js
+++ b/src/themes/mat/index.js
@@ -1,9 +1,23 @@
 import { stripUnit } from 'polished';
 
-import { cssReset } from '../../utils/css-reset';
-
 import colors from './colors';
 import variables from './variables';
+
+const cssReset = `
+	/* Font reset: 1rem = 10px */
+	html {
+		font-size: 62.5%;
+	}
+	body {
+		font-size: 1.6rem;
+		margin: 0;
+	}
+	/* HTML5 display-role reset for older browsers */
+	article, aside, details, figcaption, figure,
+	footer, header, hgroup, menu, nav, section, main {
+    	display: block;
+	}
+`
 
 const global = `
 	@import url('https://fonts.googleapis.com/css?family=Ubuntu|Cabin:400,700');

--- a/src/themes/mat/index.js
+++ b/src/themes/mat/index.js
@@ -1,24 +1,20 @@
 import { stripUnit } from 'polished';
+
+import { cssReset } from '../../utils/css-reset';
+
 import colors from './colors';
 import variables from './variables';
 
 const global = `
 	@import url('https://fonts.googleapis.com/css?family=Ubuntu|Cabin:400,700');
 
-	* {
-		box-sizing: border-box;
-	}
+	${cssReset}
 
 	body {
-		padding: 0;
-		margin: 0;
+		color: ${colors[colors.skinColors.type]};
 		font-family: ${variables.mainFont};
-		position: relative;
-		cursor: auto;
-	}
-
-	nav {
-		text-transform: uppercase;
+		font-size: ${variables.uiRegularSize};
+		line-height: ${variables.uiRegularLineHeight};
 	}
 `;
 

--- a/src/themes/mat/index.js
+++ b/src/themes/mat/index.js
@@ -17,7 +17,7 @@ const cssReset = `
 	footer, header, hgroup, menu, nav, section, main {
     	display: block;
 	}
-`
+`;
 
 const global = `
 	@import url('https://fonts.googleapis.com/css?family=Ubuntu|Cabin:400,700');

--- a/src/themes/seher/index.js
+++ b/src/themes/seher/index.js
@@ -1,4 +1,7 @@
 import { darken, lighten } from 'polished';
+
+import { cssReset } from '../../utils/css-reset';
+
 import { variables } from './variables';
 
 const colorsToShade= {
@@ -20,40 +23,44 @@ const shadedColors = Object.keys(colorsToShade).map(color => ({
 
 const combinedShadedColors = shadedColors.reduce((acc, cur) => Object.assign(acc, cur), {});
 
+const colors = {
+	darkness: '#272727',
+
+	grayTint: '#C0C0C0',
+	grayTintLight: '#ECECEC',
+	grayTintLightDark: '#C0C0C0',
+	grayTintDark: '#767676',
+
+	...combinedShadedColors,
+
+	skinColors: {
+		type: 'darkness',
+		splashBackground: 'primary',
+		splashBorder: 'darkness',
+		splashText: 'white',
+		calmBackground: 'grayTintLight',
+		calmBorder: 'darkness',
+		calmText: 'tertiary',
+	},
+};
+
 const global = `
 	@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,800');
 
-	* {
-		box-sizing: border-box;
-	}
+	${cssReset}
 
 	body {
+		color: ${colors[colors.skinColors.darkness]};
 		font-family: ${variables.mainFont};
+		font-size: ${variables.uiRegularSize};
+		line-height: ${variables.uiRegularLineHeight};
+		font-weight: 300;
 	}
 `;
 
 export default {
 	name: 'SeHer',
-	colors: {
-		darkness: '#272727',
-
-		grayTint: '#C0C0C0',
-		grayTintLight: '#ECECEC',
-		grayTintLightDark: '#C0C0C0',
-		grayTintDark: '#767676',
-
-		...combinedShadedColors,
-
-		skinColors: {
-			type: 'darkness',
-			splashBackground: 'primary',
-			splashBorder: 'darkness',
-			splashText: 'white',
-			calmBackground: 'grayTintLight',
-			calmBorder: 'darkness',
-			calmText: 'tertiary',
-		},
-	},
+	colors,
 	global,
 	variables,
 };

--- a/src/themes/sol/index.js
+++ b/src/themes/sol/index.js
@@ -1,3 +1,5 @@
+import { cssReset } from '../../utils/css-reset';
+
 import colors from './colors';
 import variables from './variables';
 
@@ -6,8 +8,13 @@ import variables from './variables';
 const global = `
 	@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,700,800');
 
-	* {
-		box-sizing: border-box;
+	${cssReset}
+
+	body {
+		color: ${colors[colors.skinColors.type]};
+		font-family: ${variables.mainFont};
+		font-size: ${variables.uiRegularSize};
+		line-height: ${variables.uiRegularLineHeight};
 	}
 
 	a {

--- a/src/utils/css-reset.js
+++ b/src/utils/css-reset.js
@@ -26,8 +26,8 @@ export const cssReset = css`
 
 	html {
 		font-size: 62.5%; /* Corrects text resizing oddly in IE6/7 when body font-size is set using em units http://clagnut.com/blog/348/#c790 */
-		-webkit-text-size-adjust: 100%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
-		-ms-text-size-adjust:     100%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
+		-webkit-text-size-adjust: 62.5%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
+		-ms-text-size-adjust:     62.5%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
 	}
 
 	*,


### PR DESCRIPTION
Remove half-assed reset styles from ShinyThemeProvider, and replace them with full-grown reset styles in each theme.

When reset styles are in the theme, you can also put @import rules before your other styles, so that they will parse properly. Fixes #585

#### Please tick a box ###
- [x] **feature** _(A new feature_)

#### If you're adding a feature, is it documented in a storybook story?
- [x] Yes

#### Are the components you're working on reusable between brands?
- [x] Not working on any components

#### If you're creating markup, did you add proper semantics? 
- [x] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
