### PR TITLE
feature(DymoHeading): Change heading color on plug hover

### DIFF
--- a/src/atoms/DymoHeading.js
+++ b/src/atoms/DymoHeading.js
@@ -30,34 +30,36 @@ const FormattedHeading = styled(Heading)`
 
 const PaddedText = styled.span`
 	${props => (props.hasImage ? '' : 'max-width: 100%;')}
-	 	margin: 0;
-		padding-top: 0;
+	margin: 0;
+	padding-top: 0;
+	box-shadow:
+		calc(1/2 * ${getVariable('horizontalBase')})
+		0
+		${props => getColor(props.skin.backgroundColor)}
+	;
+	background: ${props => getColor(props.skin.backgroundColor)};
+	color:      ${props => getColor(props.skin.textColor)};
+	-webkit-box-decoration-break: clone;
+
+	span.highlighted {
+		color: ${getColor('red')};
+	}
+
+	padding-left: ${props => (props.skin.needsPadding ? `calc(1/2 * ${props.theme.variables.horizontalBase})` : '0')};
+
+	a:hover & {
+		color: ${props => (props.skin.textHoverColor ? getColor(props.skin.textHoverColor) : 'inherit')};
+		background: ${props => getColor(props.skin.backgroundColor, props.skin.backgroundHoverShade)};
 		box-shadow:
 			calc(1/2 * ${getVariable('horizontalBase')})
 			0
-		  ${props => getColor(props.skin.backgroundColor)}
+			${props => getColor(props.skin.backgroundColor, props.skin.backgroundHoverShade)}
 		;
-		background: ${props => getColor(props.skin.backgroundColor)};
-		color:      ${props => getColor(props.skin.textColor)};
-		-webkit-box-decoration-break: clone;
-
-		span.highlighted {
-			color: ${getColor('red')};
-		}
-
-		padding-left: ${props => (props.skin.needsPadding ? `calc(1/2 * ${props.theme.variables.horizontalBase})` : '0')};
-
-		a:hover & {
-			background: ${props => getColor(props.skin.backgroundColor, props.skin.backgroundHoverShade)};
-			box-shadow:
-				calc(1/2 * ${getVariable('horizontalBase')})
-				0
-				${props => getColor(props.skin.backgroundColor, props.skin.backgroundHoverShade)}
-			;
-		}
+	}
 `;
 PaddedText.propTypes = {
 	skin: propTypes.shape({
+		textHoverColor: propTypes.string,
 		backgroundColor: propTypes.string,
 		backgroundHoverShade: propTypes.string,
 		textColor: propTypes.string,
@@ -66,6 +68,7 @@ PaddedText.propTypes = {
 };
 PaddedText.defaultProps = {
 	skin: {
+		textHoverColor: 'inherit',
 		textColor: 'type',
 		needsPadding: false,
 		backgroundColor: 'transparent',
@@ -103,6 +106,7 @@ DymoHeading.propTypes = {
 	hasImage: propTypes.bool,
 	size: propTypes.oneOf(['small', 'medium', 'large', 'xlarge', 'huge']),
 	skin: propTypes.shape({
+		textHoverColor: propTypes.string,
 		backgroundColor: propTypes.string,
 		textColor: propTypes.string,
 		shouldTextBePadded: propTypes.bool,
@@ -115,6 +119,7 @@ DymoHeading.defaultProps = {
 	hasImage: false,
 	size: 'large',
 	skin: {
+		textHoverColor: 'dark',
 		textColor: 'type',
 		shouldTextBePadded: false,
 		backgroundColor: 'transparent',

--- a/src/atoms/DymoHeading.js
+++ b/src/atoms/DymoHeading.js
@@ -48,7 +48,7 @@ const PaddedText = styled.span`
 	padding-left: ${props => (props.skin.needsPadding ? `calc(1/2 * ${props.theme.variables.horizontalBase})` : '0')};
 
 	a:hover & {
-		color: ${props => (props.skin.textHoverColor ? getColor(props.skin.textHoverColor) : 'inherit')};
+		color: ${props => getColor(props.skin.textColor, props.skin.textHoverShade)};
 		background: ${props => getColor(props.skin.backgroundColor, props.skin.backgroundHoverShade)};
 		box-shadow:
 			calc(1/2 * ${getVariable('horizontalBase')})
@@ -59,16 +59,16 @@ const PaddedText = styled.span`
 `;
 PaddedText.propTypes = {
 	skin: propTypes.shape({
-		textHoverColor: propTypes.string,
 		backgroundColor: propTypes.string,
-		backgroundHoverShade: propTypes.string,
-		textColor: propTypes.string,
+		backgroundHoverShade: propTypes.oneOf(['dark', 'light', 'lighter', '']),
 		needsPadding: propTypes.bool,
+		textColor: propTypes.string,
+		textHoverShade: propTypes.oneOf(['dark', 'light', 'lighter', '']),
 	}),
 };
 PaddedText.defaultProps = {
 	skin: {
-		textHoverColor: 'inherit',
+		textHoverShade: '',
 		textColor: 'type',
 		needsPadding: false,
 		backgroundColor: 'transparent',

--- a/src/atoms/DymoHeading.js
+++ b/src/atoms/DymoHeading.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import styled, { css } from 'styled-components';
+import shinyPropTypes from '../prop-types';
 import { getColor, getVariable } from '../utils';
 
 import { Heading } from '..';
@@ -59,20 +60,20 @@ const PaddedText = styled.span`
 `;
 PaddedText.propTypes = {
 	skin: propTypes.shape({
-		backgroundColor: propTypes.string,
-		backgroundHoverShade: propTypes.oneOf(['dark', 'light', 'lighter', '']),
+		backgroundColor: shinyPropTypes.color,
+		backgroundHoverShade: shinyPropTypes.shade,
 		needsPadding: propTypes.bool,
-		textColor: propTypes.string,
-		textHoverShade: propTypes.oneOf(['dark', 'light', 'lighter', '']),
+		textColor: shinyPropTypes.color,
+		textHoverShade: shinyPropTypes.shade,
 	}),
 };
 PaddedText.defaultProps = {
 	skin: {
-		textHoverShade: '',
-		textColor: 'type',
-		needsPadding: false,
 		backgroundColor: 'transparent',
 		backgroundHoverShade: 'dark',
+		needsPadding: false,
+		textColor: 'type',
+		textHoverShade: '',
 	},
 };
 
@@ -106,10 +107,11 @@ DymoHeading.propTypes = {
 	hasImage: propTypes.bool,
 	size: propTypes.oneOf(['small', 'medium', 'large', 'xlarge', 'huge']),
 	skin: propTypes.shape({
-		textHoverColor: propTypes.string,
-		backgroundColor: propTypes.string,
-		textColor: propTypes.string,
-		shouldTextBePadded: propTypes.bool,
+		backgroundColor: shinyPropTypes.color,
+		backgroundHoverShade: shinyPropTypes.shade,
+		needsPadding: propTypes.bool,
+		textColor: shinyPropTypes.color,
+		textHoverShade: shinyPropTypes.shade,
 	}),
 	title: propTypes.string,
 };
@@ -119,10 +121,11 @@ DymoHeading.defaultProps = {
 	hasImage: false,
 	size: 'large',
 	skin: {
-		textHoverColor: 'dark',
-		textColor: 'type',
-		shouldTextBePadded: false,
 		backgroundColor: 'transparent',
+		backgroundHoverShade: 'dark',
+		needsPadding: false,
+		textColor: 'type',
+		textHoverShade: '',
 	},
 	title: '',
 };

--- a/src/prop-types/index.js
+++ b/src/prop-types/index.js
@@ -1,0 +1,80 @@
+import { getColor } from '..';
+import defaultTheme from '../themes/default-theme';
+
+/**
+ * PropTypes uses an Error-like object for backward compatibility as people may
+ * call PropTypes directly and inspect their output. However, they don't use
+ * real Errors anymore. Their stack is not inspected anyway, and creating them
+ * is prohibitively expensive if they are created too often, such as what
+ * happens in oneOfType() for any type before the one that matched.
+ */
+function PropTypeError(message) {
+	this.message = message;
+	this.stack = '';
+}
+// Make `instanceof Error` still work for returned errors.
+PropTypeError.prototype = Error.prototype;
+
+const createChainableTypeChecker = (validate) => {
+	const checkType = (isRequired, props, propName, componentName, location, propFullName, ...rest) => {
+		componentName = componentName || '<<anonymous>>';
+		propFullName = propFullName || propName;
+
+		if (props[propName] == null) {
+			if (isRequired) {
+				if (props[propName] === null) {
+					return new PropTypeError(`The ${location} \`${propFullName}\` is marked` +
+						` as required in \`${componentName}\`, but its value is \`null\`.`);
+				}
+				return new PropTypeError(`The ${location} \`${propFullName}\` is marked ` +
+					`as required in \`${componentName}\`, but its value is \`undefined\`.`);
+			}
+			return null;
+		}
+		return validate(props, propName, componentName, location, propFullName, ...rest);
+	};
+
+	const chainedCheckType = checkType.bind(null, false);
+	chainedCheckType.isRequired = checkType.bind(null, true);
+
+	return chainedCheckType;
+};
+
+/**
+ * Validate that a color string is gettable from the theme with getColor
+ */
+const isValidShinyColor = (props, propName, componentName) => {
+	const color = getColor(props[propName])({ theme: defaultTheme });
+
+	if (!color) {
+		return new PropTypeError(`Invalid prop \`${propName}\` supplied to` +
+				` \`${componentName}\`. Validation failed. Use a color that` +
+				` exists on the default theme. The color \`${props[propName]}\`` +
+				' is fake news.');
+	}
+
+	return null;
+};
+
+/**
+ * Validate that a color shade is among the color shades we actually produce in the themes
+ */
+const isValidShade = (props, propName, componentName) => {
+	const validShades = ['dark', '', 'light', 'lighter'];
+
+	if (
+		typeof props[propName] !== 'string' ||
+		!validShades.includes(props[propName].toLowerCase())
+	) {
+		return new PropTypeError(`Invalid prop \`${propName}\` supplied to` +
+				` \`${componentName}\`. Validation failed. Use one of 'dark', '',` +
+				' \'light\', \'lighter\'.');
+	}
+
+	return null;
+};
+
+export default {
+	color: createChainableTypeChecker(isValidShinyColor),
+	shade: createChainableTypeChecker(isValidShade),
+};

--- a/src/themes/seher/index.js
+++ b/src/themes/seher/index.js
@@ -11,6 +11,7 @@ const colorsToShade= {
 
 	yellow: '#f1ca3f',
 	black: '#222222',
+	darkness: '#272727',
 };
 // Creates 4 shades of each color in colorsToShade
 // For example: primary becomes primary, primaryDark, primaryLight and primaryLighter
@@ -24,8 +25,6 @@ const shadedColors = Object.keys(colorsToShade).map(color => ({
 const combinedShadedColors = shadedColors.reduce((acc, cur) => Object.assign(acc, cur), {});
 
 const colors = {
-	darkness: '#272727',
-
 	grayTint: '#C0C0C0',
 	grayTintLight: '#ECECEC',
 	grayTintLightDark: '#C0C0C0',

--- a/stories/TrysilPlug/index.js
+++ b/stories/TrysilPlug/index.js
@@ -7,6 +7,7 @@ import kicker from './kicker';
 import allCaps from './all-caps';
 import customHeading from './custom-heading';
 import TrysilPlugWithoutBlurStory from './without-blur';
+import textColorOnHover from './text-color-hover';
 
 export default () => {
 	storiesOf('TrysilPlug', module)
@@ -16,5 +17,6 @@ export default () => {
 		.add('Custom Heading', customHeading)
 		.add('With Kicker', kicker)
 		.add('All caps', allCaps)
-		.add('Row with three plugs', rowWithThreePlugs);
+		.add('Row with three plugs', rowWithThreePlugs)
+		.add('Text color on hover', textColorOnHover);
 };

--- a/stories/TrysilPlug/index.js
+++ b/stories/TrysilPlug/index.js
@@ -15,8 +15,8 @@ export default () => {
 		.add('TrysilPlug', basicIssue)
 		.add('... without blur', TrysilPlugWithoutBlurStory)
 		.add('Custom Heading', customHeading)
+		.add('DymoHeading with hover shade', textColorOnHover)
 		.add('With Kicker', kicker)
 		.add('All caps', allCaps)
-		.add('Row with three plugs', rowWithThreePlugs)
-		.add('Text color on hover', textColorOnHover);
+		.add('Row with three plugs', rowWithThreePlugs);
 };

--- a/stories/TrysilPlug/text-color-hover.js
+++ b/stories/TrysilPlug/text-color-hover.js
@@ -1,0 +1,29 @@
+/* eslint-disable max-len */
+import React from 'react';
+
+import { Heading, HugeHeading } from '../../src/atoms/Heading';
+import { TrysilPlug } from '../../src/molecules/TrysilPlug';
+import { DymoHeading } from '../../src/atoms/DymoHeading';
+
+export default () => (
+	<section>
+		<HugeHeading>TrysilPlug</HugeHeading>
+		<p>The Heading component in TrysilPlug can be swapped out by sending in another component in the Heading prop.</p>
+
+		<Heading>Usage</Heading>
+		<TrysilPlug
+			Heading={DymoHeading}
+			headingProps={{
+				skin: {
+					textHoverColor: 'yellow',
+				},
+			}}
+			title="Hva skal vi plugge i dag, da?"
+			subtitle="Det blir vel en nyhetsartikkel igjen, tenker jeg."
+			placeholderUrl="https://2.dbstatic.no/68712816.jpg?imageId=68712816&x=4.7222222222222&y=28.976572133169&cropw=90.740740740741&croph=60.419235511714&width=98&height=49&compression=30"
+			url="https://example.com"
+			image="https://2.dbstatic.no/68712816.jpg?imageId=68712816&x=4.7222222222222&y=28.976572133169&cropw=90.740740740741&croph=60.419235511714&width=980&height=490&compression=70"
+			ratio={0.5}
+		/>
+	</section>
+);

--- a/stories/TrysilPlug/text-color-hover.js
+++ b/stories/TrysilPlug/text-color-hover.js
@@ -7,7 +7,7 @@ import { DymoHeading } from '../../src/atoms/DymoHeading';
 
 export default () => (
 	<section>
-		<HugeHeading>TrysilPlug</HugeHeading>
+		<HugeHeading>DymoHeading with shade on hover</HugeHeading>
 		<p>The Heading component in TrysilPlug can be swapped out by sending in another component in the Heading prop.</p>
 
 		<Heading>Usage</Heading>
@@ -15,7 +15,9 @@ export default () => (
 			Heading={DymoHeading}
 			headingProps={{
 				skin: {
-					textHoverColor: 'yellow',
+					textColor: 'yellow',
+					textHoverShade: 'lighter',
+					backgroundColor: 'transparent',
 				},
 			}}
 			title="Hva skal vi plugge i dag, da?"

--- a/stories/TrysilPlug/text-color-hover.js
+++ b/stories/TrysilPlug/text-color-hover.js
@@ -8,14 +8,14 @@ import { DymoHeading } from '../../src/atoms/DymoHeading';
 export default () => (
 	<section>
 		<HugeHeading>DymoHeading with shade on hover</HugeHeading>
-		<p>The Heading component in TrysilPlug can be swapped out by sending in another component in the Heading prop.</p>
+		<p>DymoHeading does not have any hover effect by default, but if you pass the skin.textHoverShade prop, it will add that shade to the textColor on hover.</p>
 
 		<Heading>Usage</Heading>
 		<TrysilPlug
 			Heading={DymoHeading}
 			headingProps={{
 				skin: {
-					textColor: 'yellow',
+					textColor: 'navy',
 					textHoverShade: 'lighter',
 					backgroundColor: 'transparent',
 				},


### PR DESCRIPTION
If providing `textColorHover` on `TrysilProp` the heading will change
color on hover.

#### Please tick a box ###
- [x] **feature** _(A new feature_)
- [ ] **fix** _(A bug fix_)
- [ ] **refactor** _(A code change that neither fixes a bug nor adds a feature_)
- [ ] **docs** _(Documentation only changes_)
- [ ] **performance** _(A code change that improves performance_)
- [ ] **style** _(Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)_)
- [ ] **build** _(Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)_)
- [ ] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)
- [ ] **test** _(Adding missing tests or correcting existing tests_)

#### If you're adding a feature, is it documented in a storybook story?
- [x] Yes
- [ ] No
- [ ] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [x] Yes _(Using variables that are defined in the default theme)_
- [ ] No _(I hard coded some values)_
- [ ] Not working on any components

#### If you're creating markup, did you add proper semantics? 
- [ ] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [ ] I added microdata from [Schema.org](http://schema.org/)
- [ ] Semantics are derived from HTML
- [ ] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
