### PR TITLE
fix:Downgrade striptag, support uglifyjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-modal": "3.5.1",
     "react-rating": "1.3.0",
     "react-stickyfill": "0.2.3",
-    "striptags": "3.1.1"
+    "striptags": "2.2.1"
   },
   "devDependencies": {
     "@aller/eslint-config-aller": "0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8063,9 +8063,9 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-striptags@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/striptags/-/striptags-3.1.1.tgz#c8c3e7fdd6fb4bb3a32a3b752e5b5e3e38093ebd"
+striptags@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/striptags/-/striptags-2.2.1.tgz#4c450b708d41b8bf39cf24c49ff234fc6aabfd32"
 
 style-loader@^0.20.3:
   version "0.20.3"


### PR DESCRIPTION
#### Please tick a box ###
- [x] **fix** _(A bug fix_)


### Problem 

Shiny is being used together with next.js, that uses uglifyjs 

version 3 of [striptags notes in its readme](https://www.npmjs.com/package/striptags) that it do not support uglifyjs. 

### Temp Solution
Do keep support we will downgrad our striptag solution.


### When can we upgrade to the latest shiny

When we are using a version of next that has this implemented: https://github.com/zeit/next.js/issues/5021 


