### PR TITLE
Test/update seher header story

### DIFF
--- a/src/atoms/LinkBarNav.js
+++ b/src/atoms/LinkBarNav.js
@@ -4,7 +4,8 @@ const LinkBarNav = styled.nav`
 	background: ${props => props.background};
 	position: relative;
 	width: ${props => props.width};
-	display: ${props => (props.isVertical ? 'inline-block' : 'block')}
+	display: ${props => (props.isVertical ? 'inline-block' : 'block')};
+	${props => (props.zIndex ? `z-index: ${props.zIndex};`: '')}
 `;
 LinkBarNav.defaultProps = {
 	isVertical: false,

--- a/src/molecules/NavWithOptionalConstrainer.js
+++ b/src/molecules/NavWithOptionalConstrainer.js
@@ -31,7 +31,7 @@ const NavWithOptionalConstrainer = ({
 		);
 	}
 	return (
-		<Nav {...rest}>
+		<Nav {...rest} zIndex={zIndex}>
 			{children}
 		</Nav>
 	);

--- a/stories/link-bars/MatStory.js
+++ b/stories/link-bars/MatStory.js
@@ -54,6 +54,7 @@ const MatStory = () => (
 			shouldFlexChildren
 			justifyContent="space-between"
 			overflow="visible"
+			zIndex={5}
 		>
 			<LinkBarBleedingLogo isListItem>
 				<LogoLink useUnderline={false}>

--- a/stories/link-bars/SeHerStory.js
+++ b/stories/link-bars/SeHerStory.js
@@ -9,6 +9,7 @@ import {
 	SeHerLogo,
 	FontIcon,
 	HugeHeading,
+	LinkBarButton,
 	LinkBarItem,
 	LinkBarDropdown,
 	VerticalLinkBar,
@@ -38,10 +39,22 @@ const LinkBarBleedingLogo = styled(LinkBarItem)`
 	z-index: 9;
 `;
 
-const SeHerDropdown = styled(LinkBarDropdown)`
+const SeHerButton = styled(LinkBarButton)`
 	font-size: 2.0rem;
 	line-height: 2.4rem;
 `;
+
+const SeHerDropdownButton = (props) => {
+	const { linkText, hide, ...rest } = props;
+	const direction = (hide === true) ? 'down' : 'up';
+
+	return (
+		<SeHerButton {...rest}>
+			{linkText}{' '}
+			<FontIcon name={`arrow-alt-${direction}`} />
+		</SeHerButton>
+	);
+};
 
 const linkProps = {
 	useUnderline: true,
@@ -69,6 +82,7 @@ const SeHerStory = () => (
 			justifyContent="space-between"
 			overflow="visible"
 			shouldAdjustForNestedPadding
+			zIndex={9}
 		>
 			<LinkBarBleedingLogo isListItem>
 				<LogoLink useUnderline={false}>
@@ -76,7 +90,7 @@ const SeHerStory = () => (
 				</LogoLink>
 			</LinkBarBleedingLogo>
 			<HorizontalLinkBar
-				isTopLevelComponent={false} // Use the full width
+				isTopLevelComponent // Use the full width
 				background="#ffffff" // A refactor to bacground='splashBackground' is on the books
 				shouldFlexChildren
 				justifyContent="space-between"
@@ -109,11 +123,12 @@ const SeHerStory = () => (
 						md
 					/>
 				</form>
-				<SeHerDropdown
+				<LinkBarDropdown
 					xs
 					md={false}
 					linkText="☰"
 					textColor="type"
+					Trigger={SeHerDropdownButton}
 				>
 					<VerticalLinkBar background="white" align="right">
 						<LinkBarLink linkText="Rød løper" url="#" {...linkProps} />
@@ -124,7 +139,7 @@ const SeHerStory = () => (
 						<LinkBarLink linkText="Video" url="#" {...linkProps} />
 						<LinkBarLink linkText="Sterke historier" url="#" {...linkProps} />
 					</VerticalLinkBar>
-				</SeHerDropdown>
+				</LinkBarDropdown>
 			</HorizontalLinkBar>
 		</HorizontalLinkBar>
 		<HorizontalLinkBar


### PR DESCRIPTION
- Adhere to z-index props on all link bars, not just top level ones.
- Update SeHer-like link bar story with dropdown adjusted to emotion
- Update Mat link bar story with z-index to keep logo bleed over neighbouring link bar

#### Please tick a box ###
- [x] **fix** _(A bug fix_)
- [x] **test** _(Adding missing tests or correcting existing tests_)

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
