### PR TITLE
fix: Increase z-index on ads modal to put it above header

### DIFF
--- a/src/atoms/LogiclessModal.js
+++ b/src/atoms/LogiclessModal.js
@@ -38,7 +38,7 @@ const CloseButton = styled(BorderedButton)`
 `;
 
 const LogiclessModal = ({
-	isOpen, closeModal, children, title, appElement, width,
+	isOpen, closeModal, children, title, appElement, width, zIndex,
 }) => {
 	Modal.setAppElement(appElement);
 	return (
@@ -53,6 +53,7 @@ const LogiclessModal = ({
 					right: 0,
 					bottom: 0,
 					backgroundColor: 'rgba(0, 0, 0, 0.66)',
+					zIndex,
 				},
 				content: {
 					width,
@@ -81,11 +82,13 @@ LogiclessModal.propTypes = {
 	closeModal: PropTypes.func.isRequired,
 	children: PropTypes.node.isRequired,
 	title: PropTypes.node.isRequired,
+	zIndex: PropTypes.number,
 };
 
 LogiclessModal.defaultProps = {
 	width: '60rem',
 	appElement: '#__next',
+	zIndex: 6,
 };
 
 


### PR DESCRIPTION
This fixes #692 with ads modal being above everything but the header on e.g. SeHer as shown in the screenshot.

z-index chosen was 6 because the header uses 4 and 5. I don't like this, can we do the header without using z-index two places or more?

Suggestions?

![image](https://user-images.githubusercontent.com/467326/45779323-ff3bfc80-bc5a-11e8-8bd7-0b53a6b15970.png)
