### PR TITLE
fix(FontIcon): Don't display fallback font for Helveticons

### DIFF
--- a/src/atoms/FontIcon.js
+++ b/src/atoms/FontIcon.js
@@ -10,6 +10,7 @@ const FontIcon = (props) => {
 			font-style: normal;
 			font-weight: normal;
 			src: url('https://styleguide.dagbladet.no/fonts/helveticons.woff') format('woff');
+			font-display: block;
 		}
 	`;
 	return <Icon {...props} />;


### PR DESCRIPTION
Leverage the font-display CSS feature to ensure icons are not user-visible
with a different font not meant for the same icons as the Helveticon webfont is loading.

Fixes dbmedialab/wolverine-frontend#846

#### Please tick a box ###
- [x] **fix** _(A bug fix_)

