### PR TITLE
fix(DontPushTheAdBoundaries): Handle different horizontalBase values

### DIFF
--- a/src/atoms/DontPushTheAdBoundaries.js
+++ b/src/atoms/DontPushTheAdBoundaries.js
@@ -1,22 +1,36 @@
-import styled from 'react-emotion';
+import styled, { css } from 'react-emotion';
 import { getColor, getVariable } from '../utils';
 
 const DontPushTheAdBoundaries = styled.div`
-	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
-	box-orient: vertical; /* ios8.x really, really needs this; overrides flex direction */
-	padding: calc(${getVariable('verticalBase')}/2) 0 0;
+	${(props) => {
+		const horizontalBase = getVariable('horizontalBase')(props);
+		const verticalBase = getVariable('verticalBase')(props);
+		const largeWidth = getVariable('largeWidth')(props);
 
-	@media (min-width: ${getVariable('largeWidth')}) {
-		position: relative;
-		width: 100%;
-		max-width: 100.0rem;
-		margin: 0 auto;
-		padding: ${getVariable('verticalBase')} .3rem 0;
-		background: ${props => props.background || getColor('white')};
-		z-index: 4;
-	}
+		const white = getColor('white')(props);
+
+		const wallpaperAdInnerWidth = '100.0rem';
+		const topbannerAdWidth = '98.0rem';
+		const largeScreenSidePadding = `calc(1/2 * (${wallpaperAdInnerWidth} - ${topbannerAdWidth} - ${horizontalBase}))`;
+
+		return css`
+			display: flex;
+			flex-direction: row;
+			flex-wrap: wrap;
+			box-orient: vertical; /* ios8.x really, really needs this; overrides flex direction */
+			padding: calc(1/2 * ${verticalBase}) 0 0;
+
+			@media (min-width: ${largeWidth}) {
+				position: relative;
+				width: 100%;
+				max-width: 100.0rem;
+				margin: 0 auto;
+				padding: ${verticalBase} ${largeScreenSidePadding} 0;
+				background: ${props.background || white};
+				z-index: 4;
+			}
+		`;
+	}}
 `;
 
 export { DontPushTheAdBoundaries };


### PR DESCRIPTION
No longer assume that the horizontalBase is 1.4rem.

#### Please tick a box ###
- [x] **fix** _(A bug fix_)

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
