### PR TITLE
refactor(AdWrapper): Add default itemtype and itemscope on ad wrapper

### DIFF
--- a/src/atoms/AdWrapper.js
+++ b/src/atoms/AdWrapper.js
@@ -46,6 +46,8 @@ AdWrapper.propTypes = {
 	height: PropTypes.string,
 	shouldHideAttribution: PropTypes.bool,
 	sticky: PropTypes.string,
+	itemType: PropTypes.string,
+	itemScope: PropTypes.bool,
 };
 
 AdWrapper.defaultProps = {
@@ -53,6 +55,8 @@ AdWrapper.defaultProps = {
 	width: '32.0rem',
 	height: '25.0rem',
 	shouldHideAttribution: false,
+	itemType: 'http://schema.org/WPAdBlock',
+	itemScope: true,
 };
 
 export { AdWrapper };

--- a/src/molecules/WallpaperAd.js
+++ b/src/molecules/WallpaperAd.js
@@ -134,8 +134,6 @@ class WallpaperAd extends Component {
 		const {
 			children,
 			height,
-			itemType,
-			itemScope,
 			shouldHideAttribution,
 		} = this.props;
 
@@ -183,8 +181,6 @@ class WallpaperAd extends Component {
 					height={height}
 					width={isWallpaper ? '1010px' : '980px'}
 					shouldHideAttribution={shouldHideAttribution}
-					itemType={itemType}
-					itemScope={itemScope}
 				>
 					{React.cloneElement(children, {
 						onMediaQueryChange: this.onMediaQueryChange.bind(this),
@@ -200,8 +196,6 @@ WallpaperAd.propTypes = {
 	height: PropTypes.string,
 	children: PropTypes.node.isRequired,
 	shouldHideAttribution: PropTypes.bool.isRequired,
-	itemType: PropTypes.string.isRequired,
-	itemScope: PropTypes.bool.isRequired,
 };
 
 WallpaperAd.defaultProps = {


### PR DESCRIPTION
#### Please tick a box ###
- [ ] **feature** _(A new feature_)
- [ ] **fix** _(A bug fix_)
- [x] **refactor** _(A code change that neither fixes a bug nor adds a feature_)
- [ ] **docs** _(Documentation only changes_)
- [ ] **performance** _(A code change that improves performance_)
- [ ] **style** _(Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)_)
- [ ] **build** _(Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)_)
- [ ] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)
- [ ] **test** _(Adding missing tests or correcting existing tests_)

#### If you're adding a feature, is it documented in a storybook story?
- [ ] Yes
- [ ] No
- [x] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [ ] Yes _(Using variables that are defined in the default theme)_
- [ ] No _(I hard coded some values)_
- [ ] Not working on any components

#### If you're creating markup, did you add proper semantics? 
- [ ] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [x] I added microdata from [Schema.org](http://schema.org/)
- [ ] Semantics are derived from HTML
- [ ] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
