### PR TITLE
feature(ColorTextBox): Use colortextbox as col optionally instead of always

### DIFF
--- a/src/atoms/ColorTextBox.js
+++ b/src/atoms/ColorTextBox.js
@@ -1,8 +1,11 @@
+import React from 'react';
 import styled from 'react-emotion';
+import PropTypes from 'prop-types';
+
 import { Col } from './Col';
 import { getColor, getVariable } from '../utils';
 
-const ColorTextBox = styled(Col)`
+const Box = styled('div')`
 	padding: calc(3/2 * ${getVariable('verticalBase')}) calc(3 * ${getVariable('horizontalBase')});
 	font-size:   ${getVariable('headingRegularSize')};
 	line-height: ${getVariable('headingRegularLineHeight')};
@@ -12,8 +15,6 @@ const ColorTextBox = styled(Col)`
 	text-align: left;
 	color:            ${props => getColor(props.textColor)};
 	background-color: ${props => getColor(props.bgColor)};
-	width: 100%;
-	height: 100%;
 
 	display: flex;
 	align-items: center;
@@ -23,9 +24,38 @@ const ColorTextBox = styled(Col)`
 	}
 `;
 
+const ColorTextBox = ({ column, ...rest }) => {
+	const Element = column ? Col : 'div';
+	const StyledBox = Box.withComponent(Element);
+
+	return <StyledBox {...column} {...rest} />;
+};
+
+ColorTextBox.propTypes = {
+	/** Color name from theme */
+	bgColor: PropTypes.string,
+	/** Column object to decide whether the article should be a Col or not */
+	column: PropTypes.shape({
+		width: PropTypes.number,
+		reverse: PropTypes.bool,
+		xs: PropTypes.number,
+		sm: PropTypes.number,
+		md: PropTypes.number,
+		lg: PropTypes.number,
+		xsOffset: PropTypes.number,
+		smOffset: PropTypes.number,
+		mdOffset: PropTypes.number,
+		lgOffset: PropTypes.number,
+		children: PropTypes.node,
+	}),
+	/** Color name from theme */
+	textColor: PropTypes.string,
+};
+
 ColorTextBox.defaultProps = {
-	textColor: 'white',
 	bgColor: 'primary',
+	column: null,
+	textColor: 'white',
 };
 
 

--- a/stories/editorialMarking/colorTextBoxAsCol.js
+++ b/stories/editorialMarking/colorTextBoxAsCol.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from 'react-emotion';
+
+import {
+	Row, Col, HugeHeading, Heading,
+} from '../../src';
+import { Code } from '../../src/atoms/Code';
+import { ColorTextBox } from '../../src/atoms/ColorTextBox';
+
+const TallCol = styled(Col)`
+	height: 60rem;
+`;
+
+export default () => (
+	<section>
+		<Row>
+			<Col xs={12}>
+				<HugeHeading>Description</HugeHeading>
+				<Heading>Demo</Heading>
+
+				<Row>
+					<TallCol xs={8}>I am a column, and so should the colored box be.</TallCol>
+
+					<ColorTextBox column={{ xs: 4 }}>
+						<span>
+							Helstekt kalkun er en selvfølge på
+							middagsbordet ved Thanksgiving, jul
+							og nyttår! For en smakfull og saftig
+							kalkun anbefaler vi denne oppskriften.
+						</span>
+					</ColorTextBox>
+				</Row>
+
+				<Heading>Usage</Heading>
+				<Code language="jsx">
+					{`
+import { ColorTextBox } from '@aller/shiny';
+
+<ColorTextBox textColor="white" bgColor="primary">
+	<span>
+		Lorem ipsum dolor sit amet,
+		consectetur adipisicing elit.
+		Deserunt doloribus ducimus
+		illum, iusto laborum maxime
+		optio placeat soluta vitae
+		voluptates. Animi ea eos
+		labore non officia pariatur
+		quaerat similique ut.
+	</span>
+</ColorTextBox>
+				`}
+				</Code>
+			</Col>
+		</Row>
+	</section>
+);

--- a/stories/editorialMarking/index.js
+++ b/stories/editorialMarking/index.js
@@ -9,6 +9,7 @@ import label from './label';
 import publishedDate from './publishedDate';
 import tag from './tag';
 import colorTextBox from './colorTextBox';
+import colorTextBoxAsCol from './colorTextBoxAsCol';
 
 export default () => {
 	storiesOf('Editorial Marking|Kicker', module)
@@ -35,5 +36,6 @@ export default () => {
 
 	storiesOf('Editorial Marking|ColorTextBox', module)
 		.addDecorator(StorybookPaddedGrid)
-		.add('ColorTextBox', colorTextBox);
+		.add('ColorTextBox', colorTextBox)
+		.add('... as Col', colorTextBoxAsCol);
 };


### PR DESCRIPTION
Copy the interface from TrysilPlug to optionally use the component as a Col in a Grid.

#### Please tick a box ###
- [x] **feature** _(A new feature_)

#### If you're adding a feature, is it documented in a storybook story?
- [x] Yes

#### Are the components you're working on reusable between brands?
- [x] Yes _(Using variables that are defined in the default theme)_

#### If you're creating markup, did you add proper semantics? 
- [x] Not applicable