### PR TITLE
fix(Dropdown): Account for emotion 10 JIT style tags

### DIFF
--- a/src/atoms/VerticalFlexingList.js
+++ b/src/atoms/VerticalFlexingList.js
@@ -19,7 +19,7 @@ const VerticalFlexingList = styled.ul`
 		width: auto;
 	}
 
-	${LinkBarDropdown} + div & {
+	${LinkBarDropdown} ~ div & {
 		display: ${props => (props.hide ? 'none' : 'flex')};
 		flex-direction: column;
 		min-width: calc(14 * ${getVariable('horizontalBase')});


### PR DESCRIPTION
In emotion 10, style tags will be inserted just in time. That means that
they might be inserted just before this component. Which again means
that this component no longer will be an adjacent sibling to the
dropdown button in LinkBarDropdown in our most common use case.

Therefore, we switch to the general sibling selector.

#### Please tick a box ###
- [x] **fix** _(A bug fix_)

#### If you're adding a feature, is it documented in a storybook story?
- [x] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [x] Yes _(Using variables that are defined in the default theme)_

#### If you're creating markup, did you add proper semantics? 
- [x] There are [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)

