### PR TITLE
fix(SvgIcon): removed <title> from DagbladetVideo and BackNav icons.

### DIFF
--- a/src/atoms/SvgIcon/BackNav.js
+++ b/src/atoms/SvgIcon/BackNav.js
@@ -6,7 +6,6 @@ const BackNavIcon = (props) => {
 	/* eslint-disable max-len */
 	return (
 		<svg width="100%" height="100%" viewBox="0 0 14 13" version="1.1" xmlns="http://www.w3.org/2000/svg">
-			<title>Back</title>
 			<g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
 				<g transform="translate(-1217.000000, -27.000000)" fill={color}>
 					<path

--- a/src/atoms/SvgIcon/DagbladetVideo.js
+++ b/src/atoms/SvgIcon/DagbladetVideo.js
@@ -3,7 +3,6 @@ import React from 'react';
 const DagbladetVideoIcon = () => (
 	/* eslint-disable max-len */
 	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 269.06 65.5">
-		<title>Dagbladet Video</title>
 		<g>
 			<g>
 				<rect width="207.52" height="65.5" fill="#d60000" />


### PR DESCRIPTION
# Overview
On dagbladet video pages we've had multiple `<title>` tags because of these icons. Problem was that our application [vaktsjef](https://github.com/dbmedialab/vaktsjef) parses video urls and concatenates all `<title>` making the final title somewhat-unreadable, i.e.: "Normal video titleDagbladet VideoBack". This should fix the issue.

#### Please tick a box ###
- [ ] **feature** _(A new feature_)
- [x] **fix** _(A bug fix_)
- [ ] **refactor** _(A code change that neither fixes a bug nor adds a feature_)
- [ ] **docs** _(Documentation only changes_)
- [ ] **performance** _(A code change that improves performance_)
- [ ] **style** _(Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)_)
- [ ] **build** _(Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)_)
- [ ] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)
- [ ] **test** _(Adding missing tests or correcting existing tests_)

#### If you're adding a feature, is it documented in a storybook story?
- [ ] Yes
- [ ] No
- [x] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [ ] Yes _(Using variables that are defined in the default theme)_
- [ ] No _(I hard coded some values)_
- [x] Not working on any components

#### If you're creating markup, did you add proper semantics? 
- [ ] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [ ] I added microdata from [Schema.org](http://schema.org/)
- [ ] Semantics are derived from HTML
- [x] Not applicable

