### PR TITLE
fix(Carousel): Add missing aria labels

### DIFF
--- a/src/molecules/Carousel.js
+++ b/src/molecules/Carousel.js
@@ -227,6 +227,7 @@ class Carousel extends React.Component {
 					</CarouselSlotList>
 					{prevArrowVisible && (
 						<CarouselButton
+							aria-label="Scroll to previous items"
 							vertical={vertical}
 							onClick={() => this.doSliding('prev')}
 							horizontalArrowOffset={horizontalArrowOffset}
@@ -238,6 +239,7 @@ class Carousel extends React.Component {
 					{nextArrowVisible && (
 						<CarouselButton
 							next
+							aria-label="Scroll to next items"
 							vertical={vertical}
 							onClick={() => this.doSliding('next')}
 							horizontalArrowOffset={horizontalArrowOffset}


### PR DESCRIPTION
These labels makes the buttons more intuitive for use with screen
readers. For more information, see
https://dequeuniversity.com/rules/axe/2.2/button-name

An even better solution would have been to internationalize these
strings, so that we could have for example norwegian text on norwegian
sites, and danish text on danish sites.

#### Please tick a box ###
- [x] **fix** _(A bug fix_)

#### If you're adding a feature, is it documented in a storybook story?
- [x] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [x] Yes _(Using variables that are defined in the default theme)_

#### If you're creating markup, did you add proper semantics? 
- [x] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [ ] I added microdata from [Schema.org](http://schema.org/)
- [ ] Semantics are derived from HTML
- [ ] Not applicable
