### PR TITLE
fix(ad-wrappers): Use forwardRef to adhere to emotion 10 refs

### DIFF
--- a/src/atoms/AdWrapper.js
+++ b/src/atoms/AdWrapper.js
@@ -1,3 +1,4 @@
+import React, { forwardRef } from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
@@ -9,7 +10,7 @@ const setTextAlign = (sticky) => {
 	return 'center';
 };
 
-const AdWrapper = styled.div`
+const AdWrapperBase = styled.div`
 	width: ${props => props.width};
 	height: auto;
 	min-height: calc(${props => props.height} + ${getVariable('verticalBase')});
@@ -41,7 +42,7 @@ const AdWrapper = styled.div`
 `;
 
 
-AdWrapper.propTypes = {
+AdWrapperBase.propTypes = {
 	width: PropTypes.string,
 	height: PropTypes.string,
 	shouldHideAttribution: PropTypes.bool,
@@ -50,7 +51,7 @@ AdWrapper.propTypes = {
 	itemScope: PropTypes.bool,
 };
 
-AdWrapper.defaultProps = {
+AdWrapperBase.defaultProps = {
 	sticky: '',
 	width: '32.0rem',
 	height: '25.0rem',
@@ -58,5 +59,7 @@ AdWrapper.defaultProps = {
 	itemType: 'http://schema.org/WPAdBlock',
 	itemScope: true,
 };
+
+const AdWrapper = forwardRef((props, ref) => <AdWrapperBase ref={ref} {...props} />);
 
 export { AdWrapper };

--- a/src/molecules/FullscreenAd.js
+++ b/src/molecules/FullscreenAd.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
@@ -55,16 +55,16 @@ const StyledWrapper = styled.div`
 `;
 
 
-const FullscreenAd = (props) => {
+const FullscreenAd = forwardRef((props, ref) => {
 	const { shouldHide } = props;
 
 	return (
-		<StyledReserveSpacer shouldHide={shouldHide}>
+		<StyledReserveSpacer shouldHide={shouldHide} ref={ref}>
 			<AdWrapper width="100%" />
 			<StyledWrapper {...props}  />
 		</StyledReserveSpacer>
 	);
-};
+});
 
 FullscreenAd.propTypes = {
 	shouldHide: PropTypes.bool.isRequired,

--- a/src/molecules/StickyAd.js
+++ b/src/molecules/StickyAd.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
@@ -18,37 +18,33 @@ const StickyWrapper = styled.div`
 	top: ${props => props.theme.variables.verticalBase};
 
 	@media screen and (min-width: ${props => props.theme.flexboxgrid.breakpoints.xs}em) {
-		${props => (
-		props.sticky === 'right'
-			? 'left: 100%;'
-			: 'right: 100%;'
-	)}}
-	${props => ['sm', 'md', 'lg'].map(size => css`
-		@media screen and (min-width: ${props.theme.flexboxgrid.breakpoints[size]}em) {
-			${(props => (
-		props.sticky === 'right'
-			? `left: calc(50% + 1/2 * ${props.theme.flexboxgrid.container[size]}rem);`
-			: `right: calc(50% + 1/2 * ${props.theme.flexboxgrid.container[size]}rem);`
-	))(props)}}
-
-		`)}
+		${props => (props.sticky === 'right' ? 'left: 100%;' : 'right: 100%;')}
+	}
+	${props => ['sm', 'md', 'lg'].map(
+		size => css`
+				@media screen and (min-width: ${props.theme.flexboxgrid.breakpoints[size]}em) {
+					${(props => (props.sticky === 'right'
+		? `left: calc(50% + 1/2 * ${props.theme.flexboxgrid.container[size]}rem);`
+		: `right: calc(50% + 1/2 * ${props.theme.flexboxgrid.container[size]}rem);`))(props)}
+				}
+			`
+	)}
 
 	height: 100%;
-	width: 30.0rem;
-	`;
+	width: 30rem;
+`;
 
-
-const StickyAd = ({
+const StickyAd = forwardRef(({
 	children, width, height, sticky, shouldHideAttribution,
-}) => (
-	<StickyWrapper sticky={sticky}>
+}, ref) => (
+	<StickyWrapper sticky={sticky} ref={ref}>
 		<Sticker>
 			<StyledAdWrapper height={height} width={width} shouldHideAttribution={shouldHideAttribution}>
 				{children}
 			</StyledAdWrapper>
 		</Sticker>
 	</StickyWrapper>
-);
+));
 
 StickyAd.propTypes = {
 	width: PropTypes.string,


### PR DESCRIPTION
Emotion 10 introduced using `forwardRef`, which means instead of passing the old prop of `innerRef` to any styled component you can now pass `ref` as in normal React components. Emotion currently supports both but are spewing deprecation warnings when using `innerRef`.

This change will allow us to use `ref`.

We need to pass along `ref` in the parent ad components in wolverine because of intersection observer render props need a DOM element to track.