### PR TITLE
fix(ScrollArrowsLinkBar): Use ref instead of innerRef as per emotion 10

### DIFF
--- a/src/molecules/ScrollArrowsLinkBar.js
+++ b/src/molecules/ScrollArrowsLinkBar.js
@@ -137,7 +137,7 @@ class ScrollArrowsLinkBar extends Component {
 				zIndex={zIndex}
 				isTopLevelComponent={isTopLevelComponent}
 			>
-				<Container innerRef={(input) => { this.container = input; }}>
+				<Container ref={(input) => { this.container = input; }}>
 					{shouldDrawLeftArrow
 						&& (
 							<LeftScrollArrow
@@ -151,7 +151,7 @@ class ScrollArrowsLinkBar extends Component {
 						)
 					}
 					<Bar
-						innerRef={(input) => { this.content = input; }}
+						ref={(input) => { this.content = input; }}
 						background={background}
 						backgroundColor={backgroundColor}
 						{...rest}


### PR DESCRIPTION
#### Please tick a box ###
- [ ] **feature** _(A new feature_)
- [x] **fix** _(A bug fix_)
- [ ] **refactor** _(A code change that neither fixes a bug nor adds a feature_)
- [ ] **docs** _(Documentation only changes_)
- [ ] **performance** _(A code change that improves performance_)
- [ ] **style** _(Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)_)
- [ ] **build** _(Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)_)
- [ ] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)
- [ ] **test** _(Adding missing tests or correcting existing tests_)

#### If you're adding a feature, is it documented in a storybook story?
- [ ] Yes
- [ ] No
- [ ] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [ ] Yes _(Using variables that are defined in the default theme)_
- [ ] No _(I hard coded some values)_
- [ ] Not working on any components

#### If you're creating markup, did you add proper semantics? 
- [ ] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [ ] I added microdata from [Schema.org](http://schema.org/)
- [ ] Semantics are derived from HTML
- [ ] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
