### PR TITLE
fix(SeHerLogo): make date safari friendly

### DIFF
--- a/src/atoms/SeHerLogo.js
+++ b/src/atoms/SeHerLogo.js
@@ -5,7 +5,7 @@ const now = new Date();
 
 const variantPeriods = [{
 	start: new Date('2019-06-14'),
-	end: new Date('2019-06-23 23:59:59'),
+	end: new Date('2019-06-23T23:59:59'),
 	variant: 'pride',
 }];
 


### PR DESCRIPTION
The dates were not readable by safari, causing no moment to be a pride moment if you used Safari :(

Now, pride will commence for safari users as well!

#### Please tick a box ###
- [x] **fix** _(A bug fix_)

#### If you're adding a feature, is it documented in a storybook story?
- [x] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [x] Yes _(Using variables that are defined in the default theme)_

#### If you're creating markup, did you add proper semantics? 
- [x] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
