### PR TITLE
fix(VerticalFlexingList, LinkBarDropdown): Allow for scrollers in dropdowns

### DIFF
--- a/src/atoms/VerticalFlexingList.js
+++ b/src/atoms/VerticalFlexingList.js
@@ -21,7 +21,7 @@ const VerticalFlexingList = styled.ul`
 		width: auto;
 	}
 
-	${LinkBarDropdown} ~ div > & {
+	${LinkBarDropdown} ~ div & {
 		display: ${props => (props.hide ? 'none' : 'flex')};
 		flex-direction: column;
 		min-width: calc(14 * ${getVariable('horizontalBase')});
@@ -30,6 +30,7 @@ const VerticalFlexingList = styled.ul`
 		left: ${props => (props.align === 'left' ? 0 : 'initial')};
 		right: ${props => (props.align === 'right' ? 0 : 'initial')};
 		box-shadow: ${({ boxShadow }) => boxShadow};
+
 		${({ shouldFadeOut }) => shouldFadeOut && css`
 			animation: fadeSlideDown 0.2s;
 			@keyframes fadeSlideDown {
@@ -46,6 +47,7 @@ const VerticalFlexingList = styled.ul`
 				}
 			}
 		`}
+
 		::before {
 			content: '';
 			display: ${({ hideArrow }) => (hideArrow? 'none' : 'block')};

--- a/stories/link-bar-elements/DropdownStory.js
+++ b/stories/link-bar-elements/DropdownStory.js
@@ -108,7 +108,15 @@ const DropdownStory = () => {
 					<LargeLinkBarDropdown linkText="Drop Down My Shoe" url="https://example.com" displayInitially>
 						<VerticalLinkBar backgroundColor="white">
 							<LinkBarLink linkText="One" url="https://example.com" isActive />
-							<LinkBarLink linkText="Two" url="https://example.com" />
+							<LinkBarDropdown linkText="Nested Dropdown!" url="https://example.com" displayInitially zIndex={9}>
+								<VerticalLinkBar backgroundColor="white">
+									<LinkBarLink linkText="One" url="https://example.com" isActive />
+									<LinkBarLink linkText="Two" url="https://example.com" />
+								</VerticalLinkBar>
+							</LinkBarDropdown>
+							<LinkBarLink linkText="Three" url="https://example.com" />
+							<LinkBarLink linkText="Four" url="https://example.com" />
+							<LinkBarLink linkText="Five" url="https://example.com" />
 						</VerticalLinkBar>
 					</LargeLinkBarDropdown>
 					<LargeLinkBarDropdown


### PR DESCRIPTION
Make css targeting less specific, to allow for more custom structures
inside LinkBarDropdown elements.

Specifically, this will allow for creting a scrollable parent component
outside around a VerticalLinkBar.

#### Please tick a box ###
- [ ] **feature** _(A new feature_)
- [x] **fix** _(A bug fix_)
- [ ] **refactor** _(A code change that neither fixes a bug nor adds a feature_)
- [ ] **docs** _(Documentation only changes_)
- [ ] **performance** _(A code change that improves performance_)
- [ ] **style** _(Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)_)
- [ ] **build** _(Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)_)
- [ ] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)
- [ ] **test** _(Adding missing tests or correcting existing tests_)

#### If you're adding a feature, is it documented in a storybook story?
- [ ] Yes
- [ ] No
- [x] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [x] Yes _(Using variables that are defined in the default theme)_
- [ ] No _(I hard coded some values)_
- [ ] Not working on any components

#### If you're creating markup, did you add proper semantics? 
- [ ] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [ ] I added microdata from [Schema.org](http://schema.org/)
- [ ] Semantics are derived from HTML
- [x] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
