### PR TITLE
fix(LinkBarSearchField): switch to dorris icons

### DIFF
--- a/src/atoms/LinkBarElementBase.js
+++ b/src/atoms/LinkBarElementBase.js
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import debug from 'debug';
 
 import { themePropTypes } from '../themes/theme-prop-types';
-import { getColor, getVariable } from '../utils';
+import { getColor, getVariable, linkBarElementSizes } from '../utils';
 
 const log = debug('LinkBarElementBase');
 
@@ -47,52 +47,6 @@ const getFocusBackground = (props) => {
  * all take up the same vertical space. That way, you can stuff in
  * another item without changing the height of your LinkBar.
  */
-const linkBarElementSizes =	(props) => {
-	const { size, inset } = props;
-	const horizontalBase = getVariable('horizontalBase')(props);
-	const verticalBase = getVariable('verticalBase')(props);
-	const uiSmallSize = getVariable('uiSmallSize')(props);
-	const uiSmallLineHeight = getVariable('uiSmallLineHeight')(props);
-	const uiRegularSize = getVariable('uiRegularSize')(props);
-	const uiRegularLineHeight = getVariable('uiRegularLineHeight')(props);
-
-	// If props.inset is true, we will remove half the vertical padding
-	// We use this for elements like buttons and search forms that do not
-	// cover the entire height of the link bar
-	const insetFactor = inset ? 1/2 : 1;
-
-	let verticalPadding;
-	let horizontalPadding;
-
-	if (size === 'xsmall') {
-		verticalPadding = '0';
-		horizontalPadding = `calc(1/2 * ${horizontalBase})`;
-	} else if (size === 'small') {
-		verticalPadding = `calc(${insetFactor} * 1/2 * ( 3/2*${verticalBase} - ${uiSmallLineHeight}) )`;
-		horizontalPadding = `calc(1/2 * ${horizontalBase})`;
-	} else if (size === 'large') {
-		verticalPadding = `calc(${insetFactor} * 1/2 * ( 5/2*${verticalBase} - ${uiRegularLineHeight}) )`;
-		horizontalPadding = horizontalBase;
-	} else {
-		// size === medium
-		verticalPadding =	`calc(${insetFactor} * 1/2 * ( 2*${verticalBase} - ${uiRegularLineHeight}) )`;
-		horizontalPadding = horizontalBase;
-	}
-
-	const fontSize = ['xsmall', 'small'].includes(props.size)
-		? uiSmallSize
-		: uiRegularSize;
-	const lineHeight = ['xsmall', 'small'].includes(props.size)
-		? uiSmallLineHeight
-		: uiRegularLineHeight;
-
-	return css`
-		margin: ${inset ? `${verticalPadding} 0` : 0};
-		padding: ${verticalPadding} ${horizontalPadding};
-		font-size: ${fontSize};
-		line-height: ${lineHeight};
-	`;
-};
 
 const allcaps = props => props.ALLCAPS && css`
 	text-transform: uppercase;

--- a/src/atoms/LinkBarElementBase.js
+++ b/src/atoms/LinkBarElementBase.js
@@ -41,13 +41,6 @@ const getFocusBackground = (props) => {
 	return (activeBackgroundFromProps === 'transparent' ? 'rgba(0,0,0,.04)' : activeBackgroundFromProps);
 };
 
-/*
- * With the 'xsmall', 'small', 'medium' (default) and 'large' variants,
- * LinkBar items like LinkBarLinks, LinkBarButtons and LinkBarDropdowns
- * all take up the same vertical space. That way, you can stuff in
- * another item without changing the height of your LinkBar.
- */
-
 const allcaps = props => props.ALLCAPS && css`
 	text-transform: uppercase;
 	letter-spacing: .1rem;

--- a/src/atoms/LinkBarSearchField.jsx
+++ b/src/atoms/LinkBarSearchField.jsx
@@ -1,45 +1,62 @@
-import React, { Fragment } from 'react';
+/* eslint-disable jsx-a11y/label-has-for, jsx-a11y/label-has-associated-control */
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
-import { getColor, getVariable } from '../utils';
+import { getColor, getVariable, linkBarElementSizes } from '../utils';
 import { LinkBarElementBase } from './LinkBarElementBase';
-import { FontIcon } from './FontIcon';
+import { SvgIcon } from './SvgIcon';
 
-const FontIconBase = LinkBarElementBase.withComponent(FontIcon);
-const AbsoluteFontIcon = styled(FontIconBase)`
+const AbsoluteIcon = styled(SvgIcon)`
+	${linkBarElementSizes}
+
 	${(props) => {
-		const { size } = props;
+		const { fullWidth, size } = props;
 		const horizontalBase = getVariable('horizontalBase')(props);
+		const uiSmallLineHeight = getVariable('uiSmallLineHeight')(props);
+		const uiRegularLineHeight = getVariable('uiRegularLineHeight')(props);
 
 		const smallMarginFactor = size === 'small' ? 1/2 : 1;
-		const horizontalMargin = `calc(${smallMarginFactor} * ${horizontalBase})`;
+		const fullWidthFactor = 3/2;
+		const horizontalMargin = fullWidth
+			? `calc(${fullWidthFactor} * ${horizontalBase})`
+			: `calc(${smallMarginFactor} * ${horizontalBase})`;
+
+		const width = ['xsmall', 'small'].includes(props.size)
+			? uiSmallLineHeight
+			: uiRegularLineHeight;
 
 		return css`
 			position: absolute;
 			left: ${horizontalMargin};
-			font-family: "Helveticons";
+
+			svg {
+				width: ${width};
+			}
 		`;
 	}}
 `;
-
 
 const InputBase = LinkBarElementBase.withComponent('input');
 const Input = styled(InputBase)`
 	${(props) => {
 		const { size, icon, fullWidth } = props;
 		const horizontalBase = getVariable('horizontalBase')(props);
+		const uiRegularLineHeight = getVariable('uiRegularLineHeight')(props);
+		const uiSmallLineHeight = getVariable('uiSmallLineHeight')(props);
 		const placeholderColor = getColor(props.placeholderColor)(props);
 
-		const widthFactor = size === 'small' ? 9 : 13;
+		const widthFactor = size === 'small' ? 11 : 15;
 		const marginFactor = size === 'small' ? 1/2 : 1;
 
 		const horizontalMargin = `calc(${marginFactor} * ${horizontalBase})`;
 		const width = fullWidth ? `calc(100% - calc(2 * ${horizontalMargin}))` : `calc(${widthFactor} * ${horizontalBase})`;
 		let paddingLeft = '1rem';
 		if (icon) {
-			paddingLeft = size === 'small' ? '2.7rem' : '4.4rem';
+			paddingLeft = size === 'small'
+				? `calc((1 * ${horizontalBase}) + ${uiSmallLineHeight})`
+				: `calc((2 * ${horizontalBase}) + ${uiRegularLineHeight})`;
 		}
 		return css`
 			&& {
@@ -62,7 +79,7 @@ const Form = styled.form`
 	${({ fullWidth }) => fullWidth && css(`
 		width: 100%;
 	`)}
-`
+`;
 const LinkBarSearchField = ({
 	action,
 	iconColor,
@@ -70,16 +87,40 @@ const LinkBarSearchField = ({
 	formName,
 	size,
 	icon,
+	iconSet,
 	fullWidth,
 	...rest
-}) => (
-	<Fragment>
-		{icon && <AbsoluteFontIcon name={icon} size={size} textColor={iconColor} inset />}
+}) => {
+	const basicInput = (
+		<Input
+			id={inputName}
+			name={inputName}
+			size={size}
+			type="search"
+			inset
+			rounded
+			required
+			icon={icon}
+			fullWidth={fullWidth}
+			{...rest}
+		/>
+	);
+
+	const maybeLabelledInput = icon
+		? (
+			<label>
+				<AbsoluteIcon name={icon} set={iconSet} size={size} color={iconColor} inset fullWidth={fullWidth} />
+				{basicInput}
+			</label>
+		)
+		: basicInput;
+
+	return (
 		<Form id={formName} name={formName} action={action} fullWidth={fullWidth}>
-			<Input id={inputName} name={inputName} size={size} type="search" inset rounded required icon={icon} fullWidth={fullWidth} {...rest} />
+			{maybeLabelledInput}
 		</Form>
-	</Fragment>
-);
+	);
+};
 LinkBarSearchField.propTypes = {
 	/** Color name from theme. Will be used on hover or focus */
 	activeBackgroundColor: PropTypes.string,
@@ -99,6 +140,8 @@ LinkBarSearchField.propTypes = {
 	textColor: PropTypes.string,
 	/** Icon's name, for example "search", if empty(by default) icon will not render */
 	icon: PropTypes.string,
+	/** Which icon set to use. */
+	iconSet: PropTypes.string,
 	/** If true will change width to 100% except calculated margins, which depends on size and horizontalBase */
 	fullWidth: PropTypes.bool,
 };
@@ -111,7 +154,8 @@ LinkBarSearchField.defaultProps = {
 	placeholderColor: 'typeDisabled',
 	size: 'medium',
 	textColor: 'type',
-	icon: "",
+	icon: '',
+	iconSet: 'dorris',
 	fullWidth: false,
 };
 

--- a/src/atoms/SvgIcon/dorris/ArrowDown.js
+++ b/src/atoms/SvgIcon/dorris/ArrowDown.js
@@ -4,7 +4,7 @@ import Svg from './Svg';
 
 const ArrowDown = props => (
 	<Svg {...props}>
-		<polyline points="31.8,11.8 24.1,19.4 16.5,27 8.8,19.4 1.2,11.8 " />
+		<polyline points="31.8,11.8 24.1,19.4 16.5,27 8.8,19.4 1.2,11.8" />
 	</Svg>
 );
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,3 +4,4 @@ export { getVariable } from './get-variable';
 export { unshadeColorString } from './unshade-color-string';
 export { isBright, isDark } from './luminance';
 export { calculateTextColorFromName, calculateTextColorFromTheme } from './calculate-text-color';
+export { linkBarElementSizes } from './link-bar-element-sizes';

--- a/src/utils/link-bar-element-sizes.js
+++ b/src/utils/link-bar-element-sizes.js
@@ -1,6 +1,12 @@
 import { css } from '@emotion/core';
 import { getVariable } from './get-variable';
 
+/*
+ * With the 'xsmall', 'small', 'medium' (default) and 'large' variants,
+ * LinkBar items like LinkBarLinks, LinkBarButtons and LinkBarDropdowns
+ * all take up the same vertical space. That way, you can stuff in
+ * another item without changing the height of your LinkBar.
+ */
 export const linkBarElementSizes = (props) => {
 	const { size, inset } = props;
 	const horizontalBase = getVariable('horizontalBase')(props);

--- a/src/utils/link-bar-element-sizes.js
+++ b/src/utils/link-bar-element-sizes.js
@@ -1,0 +1,49 @@
+import { css } from '@emotion/core';
+import { getVariable } from './get-variable';
+
+export const linkBarElementSizes = (props) => {
+	const { size, inset } = props;
+	const horizontalBase = getVariable('horizontalBase')(props);
+	const verticalBase = getVariable('verticalBase')(props);
+	const uiSmallSize = getVariable('uiSmallSize')(props);
+	const uiSmallLineHeight = getVariable('uiSmallLineHeight')(props);
+	const uiRegularSize = getVariable('uiRegularSize')(props);
+	const uiRegularLineHeight = getVariable('uiRegularLineHeight')(props);
+
+	// If props.inset is true, we will remove half the vertical padding
+	// We use this for elements like buttons and search forms that do not
+	// cover the entire height of the link bar
+	const insetFactor = inset ? 1/2 : 1;
+
+	let verticalPadding;
+	let horizontalPadding;
+
+	if (size === 'xsmall') {
+		verticalPadding = '0';
+		horizontalPadding = `calc(1/2 * ${horizontalBase})`;
+	} else if (size === 'small') {
+		verticalPadding = `calc(${insetFactor} * 1/2 * ( 3/2*${verticalBase} - ${uiSmallLineHeight}) )`;
+		horizontalPadding = `calc(1/2 * ${horizontalBase})`;
+	} else if (size === 'large') {
+		verticalPadding = `calc(${insetFactor} * 1/2 * ( 5/2*${verticalBase} - ${uiRegularLineHeight}) )`;
+		horizontalPadding = horizontalBase;
+	} else {
+		// size === medium
+		verticalPadding =	`calc(${insetFactor} * 1/2 * ( 2*${verticalBase} - ${uiRegularLineHeight}) )`;
+		horizontalPadding = horizontalBase;
+	}
+
+	const fontSize = ['xsmall', 'small'].includes(props.size)
+		? uiSmallSize
+		: uiRegularSize;
+	const lineHeight = ['xsmall', 'small'].includes(props.size)
+		? uiSmallLineHeight
+		: uiRegularLineHeight;
+
+	return css`
+		margin: ${inset ? `${verticalPadding} 0` : 0};
+		padding: ${verticalPadding} ${horizontalPadding};
+		font-size: ${fontSize};
+		line-height: ${lineHeight};
+	`;
+};

--- a/stories/link-bar-elements/SearchFieldStory.js
+++ b/stories/link-bar-elements/SearchFieldStory.js
@@ -17,7 +17,7 @@ const SearchFieldStory = () => (
 		<HorizontalLinkBar backgroundColor="grayTintLighter">
 			<SmallLinkBarLink linkText="One" url="https://example.com" isActive />
 			<SmallLinkBarLink linkText="Two" url="https://example.com" />
-			<SmallLinkBarSearchField icon="info" placeholder="Search My Shoe" backgroundColor="white" />
+			<SmallLinkBarSearchField icon="magnifier" placeholder="Search My Shoe" backgroundColor="white" />
 		</HorizontalLinkBar>
 		<div>-</div>
 		<HorizontalLinkBar backgroundColor="grayTintLighter">


### PR DESCRIPTION
We're trying to get rid of all instances of FontIcon, one usage at a time.

This way, we're hoping to achieve performance improvements by not having to load the Helveticons font.

This change is likely to affect most of the headers in the Aller sites.

#### Please tick a box ###
- [ ] **feature** _(A new feature_)
- [x] **fix** _(A bug fix_)
- [ ] **refactor** _(A code change that neither fixes a bug nor adds a feature_)
- [ ] **docs** _(Documentation only changes_)
- [ ] **performance** _(A code change that improves performance_)
- [ ] **style** _(Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)_)
- [ ] **build** _(Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)_)
- [ ] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)
- [ ] **test** _(Adding missing tests or correcting existing tests_)

#### If you're adding a feature, is it documented in a storybook story?
- [ ] Yes
- [ ] No
- [x] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [x] Yes _(Using variables that are defined in the default theme)_
- [ ] No _(I hard coded some values)_
- [ ] Not working on any components

#### If you're creating markup, did you add proper semantics? 
- [ ] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [ ] I added microdata from [Schema.org](http://schema.org/)
- [x] Semantics are derived from HTML
- [ ] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
