### PR TITLE
fix(fonts): changed font-display of theme fonts to fallback

### DIFF
--- a/src/themes/dagbladet/index.js
+++ b/src/themes/dagbladet/index.js
@@ -16,7 +16,7 @@ const variables = {
 };
 
 const global = `
-	@import url('https://fonts.googleapis.com/css?family=Roboto:300,700,800&display=optional');
+	@import url('https://fonts.googleapis.com/css?family=Roboto:300,700,800&display=fallback');
 
 	${cssReset}
 `;

--- a/src/themes/dinside/index.js
+++ b/src/themes/dinside/index.js
@@ -14,7 +14,7 @@ const variables = {
 };
 
 const global = `
-	@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,700,800&display=optional');
+	@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,700,800&display=fallback');
 
 	${cssReset}
 

--- a/src/themes/elbil24/index.js
+++ b/src/themes/elbil24/index.js
@@ -10,7 +10,7 @@ const variables = {
 };
 
 const global = `
-	@import url('https://fonts.googleapis.com/css?family=Barlow:400,600,800,800i&display=optional');
+	@import url('https://fonts.googleapis.com/css?family=Barlow:400,600,800,800i&display=fallback');
 
 	${cssReset}
 `;

--- a/src/themes/kk/index.js
+++ b/src/themes/kk/index.js
@@ -13,8 +13,8 @@ const variables = {
 };
 
 const global = `
-	@import url('https://fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i&display=optional');
-	@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,700,800&display=optional');
+	@import url('https://fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i&display=fallback');
+	@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,700,800&display=fallback');
 
 	${cssReset}
 `;

--- a/src/themes/light-theme/index.js
+++ b/src/themes/light-theme/index.js
@@ -64,7 +64,7 @@ const colors = {
 };
 
 const global = `
-	@import url('https://fonts.googleapis.com/css?family=Roboto:300,700,800&display=optional');
+	@import url('https://fonts.googleapis.com/css?family=Roboto:300,700,800&display=fallback');
 
 	${cssReset}
 

--- a/src/themes/mat/index.js
+++ b/src/themes/mat/index.js
@@ -20,7 +20,7 @@ const cssReset = `
 `;
 
 const global = `
-	@import url('https://fonts.googleapis.com/css?family=Ubuntu|Cabin:400,700&display=optional');
+	@import url('https://fonts.googleapis.com/css?family=Ubuntu|Cabin:400,700&display=fallback');
 
 	${cssReset}
 

--- a/src/themes/seher/index.js
+++ b/src/themes/seher/index.js
@@ -47,7 +47,7 @@ const colors = {
 };
 
 const global = `
-	@import url('https://fonts.googleapis.com/css?family=Lato:300,400,700&display=optional');
+	@import url('https://fonts.googleapis.com/css?family=Lato:300,400,700&display=fallback');
 
 	${cssReset}
 `;

--- a/src/themes/sol/index.js
+++ b/src/themes/sol/index.js
@@ -6,7 +6,7 @@ import variables from './variables';
 // TODO: A pemanent solution for the a underline should be made.
 //       se: https://github.com/dbmedialab/wolverine-frontend/issues/460
 const global = `
-	@import url('https://fonts.googleapis.com/css?family=Barlow:400,700,800&display=optional');
+	@import url('https://fonts.googleapis.com/css?family=Barlow:400,700,800&display=fallback');
 	${cssReset}
 	a {
 		text-decoration: none;

--- a/src/themes/start/index.js
+++ b/src/themes/start/index.js
@@ -4,7 +4,7 @@ import colors from './colors';
 import variables from './variables';
 
 const global = `
-	@import url('https://fonts.googleapis.com/css?family=Montserrat:400,700|Open+Sans:400&display=optional');
+	@import url('https://fonts.googleapis.com/css?family=Montserrat:400,700|Open+Sans:400&display=fallback');
 
 	${cssReset}
 `;


### PR DESCRIPTION
Because we had flash of unstyled fonts for some time before correct font loaded, changed font-display to fallback. This should help a little bit by not displaying fonts at all for 100ms while it's loaded

#### Please tick a box ###
- [ ] **feature** _(A new feature_)
- [X] **fix** _(A bug fix_)
- [ ] **refactor** _(A code change that neither fixes a bug nor adds a feature_)
- [ ] **docs** _(Documentation only changes_)
- [ ] **performance** _(A code change that improves performance_)
- [ ] **style** _(Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)_)
- [ ] **build** _(Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)_)
- [ ] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)
- [ ] **test** _(Adding missing tests or correcting existing tests_)

#### If you're adding a feature, is it documented in a storybook story?
- [ ] Yes
- [ ] No
- [ ] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [ ] Yes _(Using variables that are defined in the default theme)_
- [ ] No _(I hard coded some values)_
- [ ] Not working on any components

#### If you're creating markup, did you add proper semantics? 
- [ ] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [ ] I added microdata from [Schema.org](http://schema.org/)
- [ ] Semantics are derived from HTML
- [ ] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
