### PR TITLE
fix(AdSettingsCog + SvgIconWrapper): Changed cogwheel and svgIconWrapper type

### DIFF
--- a/src/atoms/AdSettingsCog.js
+++ b/src/atoms/AdSettingsCog.js
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { getColor, getVariable } from '../utils';
 import { SvgIcon } from './SvgIcon';
 
-const StyledCog = styled.div`
+const StyledCog = styled.button`
 	position: absolute;
 	left: 0;
 	top: 0;
@@ -13,6 +13,7 @@ const StyledCog = styled.div`
 	filter: alpha(opacity=50);
 	line-height: 0;
 	cursor: pointer;
+	border-width: 0px;
 `;
 
 const AdSettingsCog = props => (

--- a/src/atoms/SvgIcon/SvgIconWrapper.js
+++ b/src/atoms/SvgIcon/SvgIconWrapper.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-const SvgIconWrapper = styled('div', {
+const SvgIconWrapper = styled('span', {
 	shouldForwardProp: prop => prop !== 'size',
 })`
 	display: inline-block;


### PR DESCRIPTION
AdSettingsCog: Changed from div to button because of wcag2 feedback
SvgIconWrapper: Changed from div to span to avoid having a block element inside button.

#### Please tick a box ###
- [ ] **feature** _(A new feature_)
- [x] **fix** _(A bug fix_)
- [ ] **refactor** _(A code change that neither fixes a bug nor adds a feature_)
- [ ] **docs** _(Documentation only changes_)
- [ ] **performance** _(A code change that improves performance_)
- [ ] **style** _(Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)_)
- [ ] **build** _(Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)_)
- [ ] **ci** _(Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)_)
- [ ] **test** _(Adding missing tests or correcting existing tests_)

#### If you're adding a feature, is it documented in a storybook story?
- [ ] Yes
- [ ] No
- [x] Not adding a new feature

#### Are the components you're working on reusable between brands?
- [ ] Yes _(Using variables that are defined in the default theme)_
- [ ] No _(I hard coded some values)_
- [x] Not working on any components

#### If you're creating markup, did you add proper semantics? 
- [ ] I added [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
- [ ] I added microdata from [Schema.org](http://schema.org/)
- [ ] Semantics are derived from HTML
- [ ] Not applicable

_(Did you do a CR and see that there is something that we should check for each PR, that are not on the list, please [update this document](https://github.com/dbmedialab/shiny/edit/master/.github/PULL_REQUEST_TEMPLATE.md))_
